### PR TITLE
p2p: update protocol magic bytes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -103,10 +103,10 @@ public:
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
          * a large 32-bit integer with any alignment.
          */
-        pchMessageStart[0] = 0xf9;
-        pchMessageStart[1] = 0xbe;
-        pchMessageStart[2] = 0xb4;
-        pchMessageStart[3] = 0xd9;
+        pchMessageStart[0] = 0xdb;
+        pchMessageStart[1] = 0xd2;
+        pchMessageStart[2] = 0xb1;
+        pchMessageStart[3] = 0xac;
         nDefaultPort = 8333;
         nPruneAfterHeight = 100000;
         m_assumed_blockchain_size = 460;
@@ -218,10 +218,10 @@ public:
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000064728c7be6fe4b2f961");
         consensus.defaultAssumeValid = uint256S("0x00000000000163cfb1f97c4e4098a3692c8053ad9cab5ad9c86b338b5c00b8b7"); // 2143398
 
-        pchMessageStart[0] = 0x0b;
-        pchMessageStart[1] = 0x11;
-        pchMessageStart[2] = 0x09;
-        pchMessageStart[3] = 0x07;
+        pchMessageStart[0] = 0xe2;
+        pchMessageStart[1] = 0xbe;
+        pchMessageStart[2] = 0x8d;
+        pchMessageStart[3] = 0xb7;
         nDefaultPort = 18333;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 40;
@@ -423,10 +423,10 @@ public:
         consensus.nMinimumChainWork = uint256{};
         consensus.defaultAssumeValid = uint256{};
 
-        pchMessageStart[0] = 0xfa;
+        pchMessageStart[0] = 0xfd;
         pchMessageStart[1] = 0xbf;
-        pchMessageStart[2] = 0xb5;
-        pchMessageStart[3] = 0xda;
+        pchMessageStart[2] = 0x9f;
+        pchMessageStart[3] = 0xfb;
         nDefaultPort = 18444;
         nPruneAfterHeight = args.GetBoolArg("-fastprune", false) ? 100 : 1000;
         m_assumed_blockchain_size = 0;


### PR DESCRIPTION
## What was done and why

So, issue #9 calls for all message prefix magic bytes (currently Bitcoin ones) to be replaced by Navcoin-specific and unique values.

The new values were generated with [this script](https://gist.github.com/isgulkov/8a77021397deeaed8ee2cae041dcdb72) and googled to ensure uniqueness. (if a byte string doesn't show up, for example, [here](https://github.com/dan-da/coinparams/blob/master/coinnetworking.md), it's very likely unused)

## How to test

- [x] `make check` passes
- [x] After building and launching it as it is, the node finds peers, but fails to pull anything from them, *as expected*
- [x] To be completely sure, I've set up a makeshift `regtest` network to see that the modified nodes communicate to each other. **With has been decided to be superfluous and should _not_ be done for every compatibility-breaking change.**

