### PR TITLE
util: use The Navcoin Core Developers in devtools/copyright_header.py

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -105,6 +105,7 @@ EXPECTED_HOLDER_NAMES = [
     r"Intel Corporation ?",
     r"The Zcash developers",
     r"Jeremy Rubin",
+    r"The Navcoin Core developers",
 ]
 
 DOMINANT_STYLE_COMPILED = {}

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -338,7 +338,7 @@ def write_file_lines(filename, file_lines):
 COPYRIGHT = r'Copyright \(c\)'
 YEAR = "20[0-9][0-9]"
 YEAR_RANGE = '(%s)(-%s)?' % (YEAR, YEAR)
-HOLDER = 'The Bitcoin Core developers'
+HOLDER = 'The Navcoin Core developers'
 UPDATEABLE_LINE_COMPILED = re.compile(' '.join([COPYRIGHT, YEAR_RANGE, HOLDER]))
 
 def get_updatable_copyright_line(file_lines):
@@ -403,24 +403,24 @@ def exec_update_header_year(base_directory):
 ################################################################################
 
 UPDATE_USAGE = """
-Updates all the copyright headers of "The Bitcoin Core developers" which were
+Updates all the copyright headers of "The Navcoin Core developers" which were
 changed in a year more recent than is listed. For example:
 
-// Copyright (c) <firstYear>-<lastYear> The Bitcoin Core developers
+// Copyright (c) <firstYear>-<lastYear> The Navcoin Core developers
 
 will be updated to:
 
-// Copyright (c) <firstYear>-<lastModifiedYear> The Bitcoin Core developers
+// Copyright (c) <firstYear>-<lastModifiedYear> The Navcoin Core developers
 
 where <lastModifiedYear> is obtained from the 'git log' history.
 
 This subcommand also handles copyright headers that have only a single year. In those cases:
 
-// Copyright (c) <year> The Bitcoin Core developers
+// Copyright (c) <year> The Navcoin Core developers
 
 will be updated to:
 
-// Copyright (c) <year>-<lastModifiedYear> The Bitcoin Core developers
+// Copyright (c) <year>-<lastModifiedYear> The Navcoin Core developers
 
 where the update is appropriate.
 
@@ -453,7 +453,7 @@ def get_header_lines(header, start_year, end_year):
     return [line + '\n' for line in lines]
 
 CPP_HEADER = '''
-// Copyright (c) %s The Bitcoin Core developers
+// Copyright (c) %s The Navcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
@@ -462,7 +462,7 @@ def get_cpp_header_lines_to_insert(start_year, end_year):
     return reversed(get_header_lines(CPP_HEADER, start_year, end_year))
 
 SCRIPT_HEADER = '''
-# Copyright (c) %s The Bitcoin Core developers
+# Copyright (c) %s The Navcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
@@ -517,7 +517,7 @@ def insert_cpp_header(filename, file_lines, start_year, end_year):
 def exec_insert_header(filename, style):
     file_lines = read_file_lines(filename)
     if file_already_has_core_copyright(file_lines):
-        sys.exit('*** %s already has a copyright by The Bitcoin Core developers'
+        sys.exit('*** %s already has a copyright by The Navcoin Core developers'
                  % (filename))
     start_year, end_year = get_git_change_year_range(filename)
     if style in ['python', 'shell']:
@@ -530,7 +530,7 @@ def exec_insert_header(filename, style):
 ################################################################################
 
 INSERT_USAGE = """
-Inserts a copyright header for "The Bitcoin Core developers" at the top of the
+Inserts a copyright header for "The Navcoin Core developers" at the top of the
 file in either Python or C++ style as determined by the file extension. If the
 file is a Python file and it has a '#!' starting the first line, the header is
 inserted in the line below it.
@@ -544,7 +544,7 @@ where <year_introduced> is according to the 'git log' history. If
 
 "<current_year>"
 
-If the file already has a copyright for "The Bitcoin Core developers", the
+If the file already has a copyright for "The Navcoin Core developers", the
 script will exit.
 
 Usage:
@@ -578,7 +578,7 @@ def insert_cmd(argv):
 ################################################################################
 
 USAGE = """
-copyright_header.py - utilities for managing copyright headers of 'The Bitcoin
+copyright_header.py - utilities for managing copyright headers of 'The Navcoin
 Core developers' in repository source files.
 
 Usage:

--- a/src/tmp.h
+++ b/src/tmp.h
@@ -1,0 +1,8 @@
+//
+// Created by matheus on 11/05/22.
+//
+
+#ifndef NAVCOIN_TMP_H
+#define NAVCOIN_TMP_H
+
+#endif //NAVCOIN_TMP_H

--- a/src/tmp.h
+++ b/src/tmp.h
@@ -1,8 +1,0 @@
-//
-// Created by matheus on 11/05/22.
-//
-
-#ifndef NAVCOIN_TMP_H
-#define NAVCOIN_TMP_H
-
-#endif //NAVCOIN_TMP_H


### PR DESCRIPTION
Closes #22

Updates copyright_header script to use Navcoin instead of Bitcoin. 
1 - Navcoin was added to the expected copyright holders, making `report` to recognize it as a valid header.
2 - Instances of Bitcoin were changed to Navcoin, making the script insert and update "Navcoin" headers instead of "Bitcoin" ones.

How to test:
Run the script commands `report`, `insert` and `update` on files. Make sure the files are *committed*, otherwise, the script can not recognize the year, thus creating an _invalid_ header.

[video with tests and minor comments](https://www.dropbox.com/s/g7uou09ja3m9k1z/issue22_testing.mp4?dl=0)

