### PR TITLE
Initialize Mcl library properly for unit testing

### DIFF
--- a/src/blsct/arith/mcl/init/static_mcl_init.h
+++ b/src/blsct/arith/mcl/init/static_mcl_init.h
@@ -13,12 +13,13 @@
 /**
  * Note that:
  * - This class initializes Mcl library for static context
- * - Define this variable before other static variables that
- *   instantiate MclG1Point class directly or indirectly are
- *   defined. Currently defined at the beginning of `MclG1Point`
- *   class definition.
+ * - Define this variable before any other static variables
+ *   that instantiate MclG1Point class directly or indirectly
+ *   are defined
  * - volatile keyword is necessary to protect the line from
  *   comipler optimization
+ * - inline keyword is necessary to force the instantiation
+ *   of the variable
  * - Defining this variable as a global variable results in
  *   memory leaks
 */

--- a/src/blsct/arith/mcl/init/static_mcl_init.h
+++ b/src/blsct/arith/mcl/init/static_mcl_init.h
@@ -18,8 +18,6 @@
  *   are defined
  * - volatile keyword is necessary to protect the line from
  *   comipler optimization
- * - inline keyword is necessary to force the instantiation
- *   of the variable
  * - Defining this variable as a global variable results in
  *   memory leaks
 */

--- a/src/blsct/arith/mcl/mcl_g1point.h
+++ b/src/blsct/arith/mcl/mcl_g1point.h
@@ -19,10 +19,10 @@
 
 class MclG1Point
 {
-// private:
-//     // This initializes Mcl library for static context before
-//     // the library is used. Needs to be defined at the beginning.
-//     static volatile StaticMclInit for_side_effect_only;
+private:
+    // This initializes Mcl library for static context before
+    // the library is used. Needs to be defined at the beginning.
+    static volatile StaticMclInit for_side_effect_only;
 public:
     MclG1Point();
     MclG1Point(const std::vector<uint8_t>& v);

--- a/src/blsct/arith/mcl/mcl_g1point.h
+++ b/src/blsct/arith/mcl/mcl_g1point.h
@@ -19,10 +19,10 @@
 
 class MclG1Point
 {
-private:
-    // This initializes Mcl library for static context before
-    // the library is used. Needs to be defined at the beginning.
-    static volatile StaticMclInit for_side_effect_only;
+// private:
+//     // This initializes Mcl library for static context before
+//     // the library is used. Needs to be defined at the beginning.
+//     static volatile StaticMclInit for_side_effect_only;
 public:
     MclG1Point();
     MclG1Point(const std::vector<uint8_t>& v);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -8,6 +8,7 @@
 
 #include <addrman.h>
 #include <banman.h>
+#include <blsct/arith/mcl/init/static_mcl_init.h>
 #include <chainparams.h>
 #include <common/url.h>
 #include <config/bitcoin-config.h>
@@ -65,6 +66,8 @@ using node::CalculateCacheSizes;
 using node::LoadChainstate;
 using node::RegenerateCommitments;
 using node::VerifyLoadedChainstate;
+
+volatile StaticMclInit m_for_side_effect_only_1;
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = nullptr;

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -93,7 +93,8 @@ struct BasicTestingSetup {
     const fs::path m_path_root;
     ArgsManager m_args;
 private:
-    volatile AtomicMclInit m_for_side_effect_only;
+    static inline volatile StaticMclInit m_for_side_effect_only_1;
+    volatile AtomicMclInit m_for_side_effect_only_2;
 };
 
 /** Testing setup that performs all steps up until right before

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -93,7 +93,7 @@ struct BasicTestingSetup {
     const fs::path m_path_root;
     ArgsManager m_args;
 private:
-    static inline volatile StaticMclInit m_for_side_effect_only_1;
+    static volatile StaticMclInit m_for_side_effect_only_1;
     volatile AtomicMclInit m_for_side_effect_only_2;
 };
 


### PR DESCRIPTION
- Initialization of Mcl library for static context in `BasicTestingSetup` to initialize Mcl before `CTxOut` is instantiated