### PR TITLE
Replace mclBnXX_clear with memset to avoid segfault in static context

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -970,6 +970,7 @@ libbitcoinkernel_la_SOURCES = \
   blsct/private_key.cpp \
   blsct/public_key.cpp \
   blsct/public_keys.cpp \
+  blsct/signature.cpp \
   chain.cpp \
   chainparamsbase.cpp \
   chainparams.cpp \

--- a/src/blsct/arith/README.md
+++ b/src/blsct/arith/README.md
@@ -57,7 +57,7 @@ Below is one way of developing a new implementation of `Generic Arith Classes`:
 
 ## Example implementation and user class
 ### Implementation
-- [Mcl](../arith/mcl/mcl.h) -- the top-level class of `Generic Arith Classes` implementation
+- [Mcl](../arith/mcl/mcl.h) -- the top-level class of `Generic Arith Classes` implementation 
 - [MclScalar](../arith/mcl/mcl_scalar.h) -- `Scalar` implementation of `Mcl`
 - [MclG1Point](../arith/mcl/mcl_g1point.h) -- `Point` implementation of `Mcl`
 

--- a/src/blsct/arith/mcl/mcl_g1point.cpp
+++ b/src/blsct/arith/mcl/mcl_g1point.cpp
@@ -8,7 +8,8 @@
 
 MclG1Point::MclG1Point()
 {
-    mclBnG1_clear(&m_p);
+    // Replacement of mclBnG1_clear to avoid segfault in static context
+    std::memset(&m_p, 0, sizeof(MclG1Point::UnderlyingType));
 }
 
 MclG1Point::MclG1Point(const std::vector<uint8_t>& v)

--- a/src/blsct/arith/mcl/mcl_scalar.cpp
+++ b/src/blsct/arith/mcl/mcl_scalar.cpp
@@ -4,6 +4,12 @@
 
 #include <blsct/arith/mcl/mcl_scalar.h>
 
+MclScalar::MclScalar()
+{
+    // Replacement of mclBnFr_clear to avoid segfault in static context
+    std::memset(&m_fr, 0, sizeof(MclScalar::UnderlyingType));
+}
+
 MclScalar::MclScalar(const int64_t& n)
 {
     mclBnFr_setInt(&m_fr, n);  // this takes int64_t

--- a/src/blsct/arith/mcl/mcl_scalar.h
+++ b/src/blsct/arith/mcl/mcl_scalar.h
@@ -28,7 +28,8 @@ using namespace std::literals::string_literals;
 class MclScalar
 {
 public:
-    MclScalar(const int64_t& n = 0);
+    MclScalar();
+    MclScalar(const int64_t& n);
     MclScalar(const std::vector<uint8_t>& v);
     template <size_t L> MclScalar(const std::array<uint8_t,L>& a);
     MclScalar(const mclBnFr& n_fr);

--- a/src/blsct/signature.cpp
+++ b/src/blsct/signature.cpp
@@ -12,6 +12,12 @@
 
 namespace blsct {
 
+Signature::Signature()
+{
+    // Replacement of mclBnG2_clear to avoid segfault in static context
+    std::memset(&m_data.v, 0, sizeof(mclBnG2));
+}
+
 Signature Signature::Aggregate(const std::vector<blsct::Signature>& sigs)
 {
     std::vector<blsSignature> bls_sigs;

--- a/src/blsct/signature.h
+++ b/src/blsct/signature.h
@@ -19,6 +19,8 @@ namespace blsct {
 class Signature
 {
 public:
+    Signature();
+
     static Signature Aggregate(const std::vector<blsct::Signature>& sigs);
 
     std::vector<uint8_t> GetVch() const;

--- a/src/test/blsct/arith/mcl/mcl_scalar_tests.cpp
+++ b/src/test/blsct/arith/mcl/mcl_scalar_tests.cpp
@@ -177,6 +177,12 @@ BOOST_AUTO_TEST_CASE(test_ctor_vec_uint8)
             BOOST_CHECK_EQUAL(a.GetString().c_str(), "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000");
         }
     }
+
+    /// default
+    {
+        MclScalar a;
+        BOOST_CHECK(mclBnFr_isZero(&a.m_fr) != 0);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(test_add)


### PR DESCRIPTION
- Replace mclBnXX_clear calls with equivalent memset calls
- Separately handle MclScalar() case in the default constructor to use memset to set 0 to the instance