### PR TITLE
BLSCT SubAddress Pool

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -162,6 +162,7 @@ task:
 task:
   name: 'ARM [unit tests, no functional tests] [bullseye]'
   << : *GLOBAL_TASK_TEMPLATE
+  container:
     docker_arguments:
       CI_IMAGE_NAME_TAG: debian:bullseye
       FILE_ENV: "./ci/test/00_setup_env_arm.sh"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -162,16 +162,11 @@ task:
 task:
   name: 'ARM [unit tests, no functional tests] [bullseye]'
   << : *GLOBAL_TASK_TEMPLATE
-  arm_container:
-    cpu: 2
-    memory: 8G
-    dockerfile: ci/test_imagefile
     docker_arguments:
       CI_IMAGE_NAME_TAG: debian:bullseye
       FILE_ENV: "./ci/test/00_setup_env_arm.sh"
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    QEMU_USER_CMD: ""  # Disable qemu and run the test natively
 
 task:
   name: 'Win64 [unit tests, no boost::process, no functional tests] [jammy]'

--- a/README.md
+++ b/README.md
@@ -78,4 +78,3 @@ Translations are periodically pulled from Transifex and merged into the git repo
 
 **Important**: We do not accept translation changes as GitHub pull requests because the next
 pull from Transifex would automatically overwrite them again.
-

--- a/ci/test/00_setup_env_android.sh
+++ b/ci/test/00_setup_env_android.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2022 The Bitcoin Core developers
+# Copyright (c) 2019-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2021 The Bitcoin Core developers
+# Copyright (c) 2019-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -6,7 +6,6 @@
 
 export LC_ALL=C.UTF-8
 
-
 export HOST=arm-linux-gnueabihf
 # The host arch is unknown, so we run the tests through qemu.
 # If the host is arm and wants to run the tests natively, it can set QEMU_USER_CMD to the empty string.

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+
 export HOST=arm-linux-gnueabihf
 # The host arch is unknown, so we run the tests through qemu.
 # If the host is arm and wants to run the tests natively, it can set QEMU_USER_CMD to the empty string.

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2022 The Bitcoin Core developers
+# Copyright (c) 2019-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_native_fuzz_with_msan.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_msan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020-2022 The Bitcoin Core developers
+# Copyright (c) 2020-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2022 The Bitcoin Core developers
+# Copyright (c) 2019-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020-2022 The Bitcoin Core developers
+# Copyright (c) 2020-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2022 The Bitcoin Core developers
+# Copyright (c) 2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2022 The Bitcoin Core developers
+# Copyright (c) 2019-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2022 The Bitcoin Core developers
+# Copyright (c) 2019-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -43,6 +43,8 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   if [ -n "${RESTART_CI_DOCKER_BEFORE_RUN}" ] ; then
     echo "Restart docker before run to stop and clear all containers started with --rm"
     systemctl restart docker
+    echo "Prune all dangling images"
+    docker image prune --force
   fi
 
   # shellcheck disable=SC2086

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -7,11 +7,11 @@
 #include <node/context.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
-#include <wallet/test/util.h>
 #include <util/translation.h>
 #include <validationinterface.h>
 #include <wallet/context.h>
 #include <wallet/receive.h>
+#include <wallet/test/util.h>
 #include <wallet/wallet.h>
 
 #include <optional>
@@ -93,11 +93,17 @@ static void WalletLoading(benchmark::Bench& bench, bool legacy_wallet)
 }
 
 #ifdef USE_BDB
-static void WalletLoadingLegacy(benchmark::Bench& bench) { WalletLoading(bench, /*legacy_wallet=*/true); }
+static void WalletLoadingLegacy(benchmark::Bench& bench)
+{
+    WalletLoading(bench, /*legacy_wallet=*/true);
+}
 BENCHMARK(WalletLoadingLegacy, benchmark::PriorityLevel::HIGH);
 #endif
 
 #ifdef USE_SQLITE
-static void WalletLoadingDescriptors(benchmark::Bench& bench) { WalletLoading(bench, /*legacy_wallet=*/false); }
+static void WalletLoadingDescriptors(benchmark::Bench& bench)
+{
+    WalletLoading(bench, /*legacy_wallet=*/false);
+}
 BENCHMARK(WalletLoadingDescriptors, benchmark::PriorityLevel::HIGH);
 #endif

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -6,6 +6,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <blsct/arith/mcl/mcl_init.h>
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <clientversion.h>
@@ -99,6 +100,7 @@ static std::optional<int> WalletAppInit(ArgsManager& args, int argc, char* argv[
 
 MAIN_FUNCTION
 {
+    volatile MclInit for_side_effect_only;
     ArgsManager& args = gArgs;
 #ifdef WIN32
     common::WinCmdLineArgs winArgs;

--- a/src/blsct/arith/elements.cpp
+++ b/src/blsct/arith/elements.cpp
@@ -5,8 +5,8 @@
 #include <blsct/arith/elements.h>
 #include <blsct/arith/mcl/mcl_g1point.h>
 #include <blsct/arith/mcl/mcl_scalar.h>
-#include <tinyformat.h>
 #include <deque>
+#include <tinyformat.h>
 
 template <typename T>
 Elements<T>::Elements()
@@ -52,7 +52,7 @@ template <typename T>
 std::vector<uint8_t> Elements<T>::GetVch() const
 {
     std::vector<uint8_t> aggr_vec;
-    for (T x: m_vec) {
+    for (T x : m_vec) {
         auto vec = x.GetVch();
         aggr_vec.insert(aggr_vec.end(), vec.begin(), vec.end());
     }
@@ -72,6 +72,19 @@ T Elements<T>::Sum() const
 }
 template MclScalar Elements<MclScalar>::Sum() const;
 template MclG1Point Elements<MclG1Point>::Sum() const;
+
+template <typename T>
+bool Elements<T>::HasZero() const
+{
+    for (T s : m_vec) {
+        if (s.IsZero()) return true;
+    }
+
+    return false;
+}
+template bool Elements<MclScalar>::HasZero() const;
+template bool Elements<MclG1Point>::HasZero() const;
+
 
 template <typename T>
 void Elements<T>::ConfirmIndexInsideRange(const uint32_t& index) const
@@ -315,11 +328,11 @@ Elements<T> Elements<T>::Invert() const
     // build:
     // - elem_inverses = (x_1, x_2, ..., x_n)^-1
     // - extract_factors = [1, x_1, x_1*x_2, ..., x_1*...*x_n]
-    Elements<T> extract_factors;  // cumulative product sequence used to cancel out inverses
-    T elem_inverse_prod;  // product of all element inverses
+    Elements<T> extract_factors; // cumulative product sequence used to cancel out inverses
+    T elem_inverse_prod;         // product of all element inverses
     {
         T n(1);
-        for (auto& x: m_vec) {
+        for (auto& x : m_vec) {
             extract_factors.Add(n);
             n = n * x;
         }
@@ -328,7 +341,7 @@ Elements<T> Elements<T>::Invert() const
 
     // calculate inverses of all elements
     std::deque<T> q;
-    size_t i = m_vec.size()-1;
+    size_t i = m_vec.size() - 1;
     for (;;) {
         // extract x_i^-1 by multiplying x_1*...*x_{i-1}
         T x = elem_inverse_prod * extract_factors[i];
@@ -341,7 +354,7 @@ Elements<T> Elements<T>::Invert() const
         --i;
     }
 
-    Elements<T> ret({ q.begin(), q.end() });
+    Elements<T> ret({q.begin(), q.end()});
     return ret;
 }
 template Elements<MclScalar> Elements<MclScalar>::Invert() const;

--- a/src/blsct/arith/elements.h
+++ b/src/blsct/arith/elements.h
@@ -33,6 +33,8 @@ public:
     bool Empty() const;
     std::vector<uint8_t> GetVch() const;
 
+    bool HasZero() const;
+
     void ConfirmIndexInsideRange(const uint32_t& index) const;
     void ConfirmSizesMatch(const size_t& other_size) const;
     static Elements<T> FirstNPow(const T& k, const size_t& n, const size_t& from_index = 0);

--- a/src/blsct/arith/mcl/mcl_g1point.cpp
+++ b/src/blsct/arith/mcl/mcl_g1point.cpp
@@ -109,10 +109,7 @@ MclG1Point MclG1Point::GetInfinity()
     static mclBnG1* g = nullptr;
     if (g == nullptr) {
         g = new mclBnG1();
-        auto g_str = "0"s;
-        if (mclBnG1_setStr(g, g_str.c_str(), g_str.length(), 10) == -1) {
-            throw std::runtime_error("MclG1Point::GetInfinity(): mclBnG1_setStr failed");
-        }
+        mclBnG1_clear(g);
     }
     MclG1Point ret(*g);
     return ret;

--- a/src/blsct/arith/mcl/mcl_g1point.cpp
+++ b/src/blsct/arith/mcl/mcl_g1point.cpp
@@ -104,6 +104,21 @@ MclG1Point MclG1Point::GetBasePoint()
     return ret;
 }
 
+MclG1Point MclG1Point::GetInfinity()
+{
+    static mclBnG1* g = nullptr;
+    if (g == nullptr) {
+        g = new mclBnG1();
+        auto g_str = "0"s;
+        if (mclBnG1_setStr(g, g_str.c_str(), g_str.length(), 10) == -1) {
+            throw std::runtime_error("MclG1Point::GetInfinity(): mclBnG1_setStr failed");
+        }
+    }
+    MclG1Point ret(*g);
+    return ret;
+}
+
+
 MclG1Point MclG1Point::MapToG1(const std::vector<uint8_t>& vec, const Endianness e)
 {
     if (vec.size() == 0) {
@@ -179,13 +194,15 @@ std::vector<uint8_t> MclG1Point::GetVch() const
     return b;
 }
 
-void MclG1Point::SetVch(const std::vector<uint8_t>& b)
+bool MclG1Point::SetVch(const std::vector<uint8_t>& b)
 {
     if (mclBnG1_deserialize(&m_p, &b[0], b.size()) == 0) {
         mclBnG1 x;
         mclBnG1_clear(&x);
         m_p = x;
+        return false;
     }
+    return true;
 }
 
 std::string MclG1Point::GetString(const uint8_t& radix) const

--- a/src/blsct/arith/mcl/mcl_g1point.h
+++ b/src/blsct/arith/mcl/mcl_g1point.h
@@ -15,7 +15,7 @@
 #include <blsct/arith/mcl/mcl_scalar.h>
 
 #include <iostream>
-#include <util/strencodings.h>  // FOR TESTING. DROP THIS!!!
+#include <util/strencodings.h> // FOR TESTING. DROP THIS!!!
 
 class MclG1Point
 {
@@ -42,6 +42,7 @@ public:
     mclBnG1 Underlying() const;
 
     static MclG1Point GetBasePoint();
+    static MclG1Point GetInfinity();
     static MclG1Point MapToG1(const std::vector<uint8_t>& vec, const Endianness e = Endianness::Little);
     static MclG1Point MapToG1(const std::string& s, const Endianness e = Endianness::Little);
     static MclG1Point HashAndMap(const std::vector<uint8_t>& vec);
@@ -51,7 +52,7 @@ public:
     bool IsZero() const;
 
     std::vector<uint8_t> GetVch() const;
-    void SetVch(const std::vector<uint8_t>& vec);
+    bool SetVch(const std::vector<uint8_t>& vec);
 
     std::string GetString(const uint8_t& radix = 16) const;
     MclScalar GetHashWithSalt(const uint64_t salt) const;

--- a/src/blsct/double_public_key.cpp
+++ b/src/blsct/double_public_key.cpp
@@ -6,12 +6,13 @@
 
 namespace blsct {
 
-DoublePublicKey::DoublePublicKey(const std::vector<unsigned char>& keys) {
+DoublePublicKey::DoublePublicKey(const std::vector<unsigned char>& keys)
+{
     if (keys.size() != SIZE) return;
-    std::vector<unsigned char> vkData(SIZE/2);
-    std::vector<unsigned char> skData(SIZE/2);
-    std::copy(keys.begin(), keys.begin()+SIZE/2, vkData.begin());
-    std::copy(keys.begin()+SIZE/2, keys.end(), skData.begin());
+    std::vector<unsigned char> vkData(SIZE / 2);
+    std::vector<unsigned char> skData(SIZE / 2);
+    std::copy(keys.begin(), keys.begin() + SIZE / 2, vkData.begin());
+    std::copy(keys.begin() + SIZE / 2, keys.end(), skData.begin());
     vk = vkData;
     sk = skData;
 }
@@ -91,4 +92,4 @@ std::vector<unsigned char> DoublePublicKey::GetVch() const
     return ret;
 }
 
-}  // namespace blsct
+} // namespace blsct

--- a/src/blsct/double_public_key.h
+++ b/src/blsct/double_public_key.h
@@ -24,12 +24,12 @@ public:
     static constexpr size_t SIZE = 48 * 2;
 
     DoublePublicKey() {}
-    DoublePublicKey(const PublicKey& vk_, const PublicKey& sk_) : vk(vk_.GetVch()), sk(sk_.GetVch()) {}
-    DoublePublicKey(const Point& vk_, const Point& sk_) : vk(vk_.GetVch()), sk(sk_.GetVch()) {}
+    DoublePublicKey(const PublicKey& vk_, const PublicKey& sk_) : vk(vk_), sk(sk_) {}
+    DoublePublicKey(const Point& vk_, const Point& sk_) : vk(vk_), sk(sk_) {}
     DoublePublicKey(const std::vector<unsigned char>& vk_, const std::vector<unsigned char>& sk_) : vk(vk_), sk(sk_) {}
     DoublePublicKey(const std::vector<unsigned char>& keys);
 
-    SERIALIZE_METHODS(DoublePublicKey, obj) { READWRITE(obj.vk.GetVch(), obj.sk.GetVch()); }
+    SERIALIZE_METHODS(DoublePublicKey, obj) { READWRITE(obj.vk, obj.sk); }
 
     uint256 GetHash() const;
     CKeyID GetID() const;
@@ -50,6 +50,6 @@ public:
     std::vector<unsigned char> GetVch() const;
 };
 
-}
+} // namespace blsct
 
-#endif  // NAVCOIN_BLSCT_DOUBLE_PUBLIC_KEY_H
+#endif // NAVCOIN_BLSCT_DOUBLE_PUBLIC_KEY_H

--- a/src/blsct/range_proof/range_proof.h
+++ b/src/blsct/range_proof/range_proof.h
@@ -69,6 +69,9 @@ struct RangeProof {
         ::Unserialize(s, a);
         ::Unserialize(s, b);
         ::Unserialize(s, t_hat);
+
+        if (Vs.HasZero() || Ls.HasZero() || Rs.HasZero() || A.IsZero() || S.IsZero() || T1.IsZero() || T2.IsZero())
+            throw std::runtime_error("RangeProof::Unserialize: Invalid proof, at least one point is infinity");
     }
 };
 

--- a/src/blsct/set_mem_proof/set_mem_proof.cpp
+++ b/src/blsct/set_mem_proof/set_mem_proof.cpp
@@ -7,25 +7,7 @@
 
 bool SetMemProof::operator==(const SetMemProof& other) const
 {
-    return phi == other.phi
-        && A1 == other.A1
-        && A2 == other.A2
-        && S1 == other.S1
-        && S2 == other.S2
-        && S3 == other.S3
-        && T1 == other.T1
-        && T2 == other.T2
-        && tau_x == other.tau_x
-        && mu == other.mu
-        && z_alpha == other.z_alpha
-        && z_tau == other.z_tau
-        && z_beta == other.z_beta
-        && t == other.t
-        && Ls == other.Ls
-        && Rs == other.Rs
-        && a == other.a
-        && b == other.b
-        && omega == other.omega;
+    return phi == other.phi && A1 == other.A1 && A2 == other.A2 && S1 == other.S1 && S2 == other.S2 && S3 == other.S3 && T1 == other.T1 && T2 == other.T2 && tau_x == other.tau_x && mu == other.mu && z_alpha == other.z_alpha && z_tau == other.z_tau && z_beta == other.z_beta && t == other.t && Ls == other.Ls && Rs == other.Rs && a == other.a && b == other.b && omega == other.omega;
 }
 
 bool SetMemProof::operator!=(const SetMemProof& other) const
@@ -56,31 +38,15 @@ void SetMemProof::Serialize(Stream& st) const
        << b
        << omega;
 }
-template
-void SetMemProof::Serialize(CDataStream& st) const;
+template void SetMemProof::Serialize(CDataStream& st) const;
 
 template <typename Stream>
 void SetMemProof::Unserialize(Stream& st)
 {
-    st >> phi
-       >> A1
-       >> A2
-       >> S1
-       >> S2
-       >> S3
-       >> T1
-       >> T2
-       >> tau_x
-       >> mu
-       >> z_alpha
-       >> z_tau
-       >> z_beta
-       >> t
-       >> Ls
-       >> Rs
-       >> a
-       >> b
-       >> omega;
+    st >> phi >> A1 >> A2 >> S1 >> S2 >> S3 >> T1 >> T2 >> tau_x >> mu >> z_alpha >> z_tau >> z_beta >> t >> Ls >> Rs >> a >> b >> omega;
+
+    if (Ls.HasZero() || Rs.HasZero() || A1.IsZero() || A2.IsZero() || S1.IsZero() || S2.IsZero() || S3.IsZero() || T1.IsZero() || T2.IsZero())
+        throw std::runtime_error("SetMemProof::Unserialize: Invalid proof, at least one point is infinity");
 }
-template
-void SetMemProof::Unserialize(CDataStream& st);
+
+template void SetMemProof::Unserialize(CDataStream& st);

--- a/src/blsct/set_mem_proof/set_mem_proof.cpp
+++ b/src/blsct/set_mem_proof/set_mem_proof.cpp
@@ -7,7 +7,25 @@
 
 bool SetMemProof::operator==(const SetMemProof& other) const
 {
-    return phi == other.phi && A1 == other.A1 && A2 == other.A2 && S1 == other.S1 && S2 == other.S2 && S3 == other.S3 && T1 == other.T1 && T2 == other.T2 && tau_x == other.tau_x && mu == other.mu && z_alpha == other.z_alpha && z_tau == other.z_tau && z_beta == other.z_beta && t == other.t && Ls == other.Ls && Rs == other.Rs && a == other.a && b == other.b && omega == other.omega;
+  return phi == other.phi
+        && A1 == other.A1
+        && A2 == other.A2
+        && S1 == other.S1
+        && S2 == other.S2
+        && S3 == other.S3
+        && T1 == other.T1
+        && T2 == other.T2
+        && tau_x == other.tau_x
+        && mu == other.mu
+        && z_alpha == other.z_alpha
+        && z_tau == other.z_tau
+        && z_beta == other.z_beta
+        && t == other.t
+        && Ls == other.Ls
+        && Rs == other.Rs
+        && a == other.a
+        && b == other.b
+        && omega == other.omega;
 }
 
 bool SetMemProof::operator!=(const SetMemProof& other) const

--- a/src/blsct/wallet/address.cpp
+++ b/src/blsct/wallet/address.cpp
@@ -5,10 +5,11 @@
 #include <blsct/wallet/address.h>
 
 namespace blsct {
-SubAddress::SubAddress(const PrivateKey &viewKey, const PublicKey &spendKey, const SubAddressIdentifier &subAddressId)
+SubAddress::SubAddress(const PrivateKey& viewKey, const PublicKey& spendKey, const SubAddressIdentifier& subAddressId)
 {
-    if(!viewKey.IsValid() || !spendKey.IsValid())
-        return;
+    if (!viewKey.IsValid() || !spendKey.IsValid()) {
+        throw std::runtime_error("blsct::SubAddress::SubAddress(): no valid blsct keys");
+    }
 
     CHashWriter string(SER_GETHASH, 0);
 
@@ -22,13 +23,8 @@ SubAddress::SubAddress(const PrivateKey &viewKey, const PublicKey &spendKey, con
     // D = B + M
     // C = a*D
     MclScalar m{string.GetHash()};
-    MclG1Point M, B;
-
-    if (!PrivateKey(m).GetPublicKey().GetG1Point(M))
-        return;
-
-    if (!spendKey.GetG1Point(B))
-        return;
+    MclG1Point M = MclG1Point::GetBasePoint() * m;
+    MclG1Point B = spendKey.GetG1Point();
 
     MclG1Point D = M + B;
     auto C = D * viewKey.GetScalar();
@@ -51,4 +47,4 @@ bool SubAddress::IsValid() const
 {
     return pk.IsValid();
 }
-}
+} // namespace blsct

--- a/src/blsct/wallet/address.h
+++ b/src/blsct/wallet/address.h
@@ -13,6 +13,22 @@
 namespace blsct {
 static const std::string subAddressHeader = "SubAddress\0";
 
+class SubAddressPool
+{
+public:
+    int64_t nTime;
+    CKeyID hashId;
+
+    SubAddressPool() : nTime(GetTime()){};
+    SubAddressPool(const CKeyID& hashIdIn) : nTime(GetTime()), hashId(hashIdIn){};
+
+
+    SERIALIZE_METHODS(SubAddressPool, obj)
+    {
+        READWRITE(obj.nTime, obj.hashId);
+    }
+};
+
 struct SubAddressIdentifier {
     uint64_t account;
     uint64_t address;
@@ -22,9 +38,10 @@ class SubAddress
 {
 private:
     DoublePublicKey pk;
+
 public:
-    SubAddress(const PrivateKey &viewKey, const PublicKey &spendKey, const SubAddressIdentifier &subAddressId);
-    SubAddress(const DoublePublicKey& pk) : pk(pk) {};
+    SubAddress(const PrivateKey& viewKey, const PublicKey& spendKey, const SubAddressIdentifier& subAddressId);
+    SubAddress(const DoublePublicKey& pk) : pk(pk){};
 
     bool IsValid() const;
 
@@ -32,6 +49,6 @@ public:
     CTxDestination GetDestination() const;
     DoublePublicKey GetKeys() const { return pk; };
 };
-}
+} // namespace blsct
 
 #endif // NAVCOIN_BLSCT_ADDRESS_H

--- a/src/blsct/wallet/hdchain.h
+++ b/src/blsct/wallet/hdchain.h
@@ -13,20 +13,21 @@ namespace blsct {
 class HDChain
 {
 public:
-    CKeyID seed_id; //!< seed hash160
+    CKeyID seed_id;  //!< seed hash160
     CKeyID spend_id; //!< spend hash160
-    CKeyID view_id; //!< view hash160
+    CKeyID view_id;  //!< view hash160
     CKeyID token_id; //!< token hash160
+    std::map<uint64_t, uint64_t> nSubAddressCounter;
 
-    static const int VERSION_HD_BASE        = 1;
-    static const int CURRENT_VERSION        = VERSION_HD_BASE;
+    static const int VERSION_HD_BASE = 1;
+    static const int CURRENT_VERSION = VERSION_HD_BASE;
     int nVersion;
 
     HDChain() { SetNull(); }
 
     SERIALIZE_METHODS(HDChain, obj)
     {
-        READWRITE(obj.nVersion, obj.seed_id, obj.spend_id, obj.view_id, obj.token_id);
+        READWRITE(obj.nVersion, obj.seed_id, obj.spend_id, obj.view_id, obj.token_id, obj.nSubAddressCounter);
     }
 
     void SetNull()
@@ -36,13 +37,14 @@ public:
         spend_id.SetNull();
         view_id.SetNull();
         token_id.SetNull();
+        nSubAddressCounter.clear();
     }
 
     bool operator==(const HDChain& chain) const
     {
-        return seed_id == chain.seed_id && spend_id == chain.spend_id && view_id == chain.view_id && token_id == chain.token_id;
+        return seed_id == chain.seed_id && spend_id == chain.spend_id && view_id == chain.view_id && token_id == chain.token_id && nSubAddressCounter == chain.nSubAddressCounter;
     }
 };
-}
+} // namespace blsct
 
 #endif // BLSCTHDCHAIN_H

--- a/src/blsct/wallet/keyring.cpp
+++ b/src/blsct/wallet/keyring.cpp
@@ -5,14 +5,14 @@
 #include <blsct/wallet/keyring.h>
 
 namespace blsct {
-bool KeyRing::AddKeyPubKey(const PrivateKey& key, const PublicKey &pubkey)
+bool KeyRing::AddKeyPubKey(const PrivateKey& key, const PublicKey& pubkey)
 {
     LOCK(cs_KeyStore);
     mapKeys[pubkey.GetID()] = key;
     return true;
 }
 
-bool KeyRing::AddViewKey(const PrivateKey& key, const PublicKey &pubkey)
+bool KeyRing::AddViewKey(const PrivateKey& key, const PublicKey& pubkey)
 {
     LOCK(cs_KeyStore);
     viewKey = key;
@@ -21,7 +21,7 @@ bool KeyRing::AddViewKey(const PrivateKey& key, const PublicKey &pubkey)
     return true;
 }
 
-bool KeyRing::AddSpendKey(const PublicKey &pubkey)
+bool KeyRing::AddSpendKey(const PublicKey& pubkey)
 {
     LOCK(cs_KeyStore);
     spendPublicKey = pubkey;
@@ -29,13 +29,13 @@ bool KeyRing::AddSpendKey(const PublicKey &pubkey)
     return true;
 }
 
-bool KeyRing::HaveKey(const CKeyID &id) const
+bool KeyRing::HaveKey(const CKeyID& id) const
 {
     LOCK(cs_KeyStore);
     return mapKeys.count(id) > 0;
 }
 
-bool KeyRing::GetKey(const CKeyID &address, PrivateKey &keyOut) const
+bool KeyRing::GetKey(const CKeyID& address, PrivateKey& keyOut) const
 {
     LOCK(cs_KeyStore);
     KeyMap::const_iterator mi = mapKeys.find(address);
@@ -45,4 +45,4 @@ bool KeyRing::GetKey(const CKeyID &address, PrivateKey &keyOut) const
     }
     return false;
 }
-}
+} // namespace blsct

--- a/src/blsct/wallet/keyring.h
+++ b/src/blsct/wallet/keyring.h
@@ -6,12 +6,13 @@
 #define KEYRING_H
 
 #include <blsct/double_public_key.h>
-#include <blsct/public_key.h>
 #include <blsct/private_key.h>
+#include <blsct/public_key.h>
 #include <sync.h>
 
 namespace blsct {
-class KeyRing {
+class KeyRing
+{
 public:
     using KeyMap = std::map<CKeyID, PrivateKey>;
 
@@ -27,19 +28,19 @@ public:
     PublicKey viewPublicKey;
     PublicKey spendPublicKey;
 
-    virtual bool AddKeyPubKey(const PrivateKey& key, const PublicKey &pubkey);
-    virtual bool AddKey(const PrivateKey &key) { return AddKeyPubKey(key, key.GetPublicKey()); }
-    virtual bool AddViewKey(const PrivateKey &key, const PublicKey& pubkey);
-    virtual bool AddSpendKey(const PublicKey &pubkey);
+    virtual bool AddKeyPubKey(const PrivateKey& key, const PublicKey& pubkey);
+    virtual bool AddKey(const PrivateKey& key) { return AddKeyPubKey(key, key.GetPublicKey()); }
+    virtual bool AddViewKey(const PrivateKey& key, const PublicKey& pubkey);
+    virtual bool AddSpendKey(const PublicKey& pubkey);
 
-    virtual bool HaveKey(const CKeyID &id) const;
-    virtual bool GetKey(const CKeyID &id, PrivateKey &keyOut) const;
+    virtual bool HaveKey(const CKeyID& id) const;
+    virtual bool GetKey(const CKeyID& id, PrivateKey& keyOut) const;
 
     virtual ~KeyRing() = default;
 
     bool fSpendKeyDefined{false};
     bool fViewKeyDefined{false};
 };
-}
+} // namespace blsct
 
 #endif // KEYRING_H

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -19,6 +19,7 @@
 static const std::string OUTPUT_TYPE_STRING_LEGACY = "legacy";
 static const std::string OUTPUT_TYPE_STRING_P2SH_SEGWIT = "p2sh-segwit";
 static const std::string OUTPUT_TYPE_STRING_BECH32 = "bech32";
+static const std::string OUTPUT_TYPE_STRING_BLSCT = "blsct";
 static const std::string OUTPUT_TYPE_STRING_BECH32M = "bech32m";
 static const std::string OUTPUT_TYPE_STRING_UNKNOWN = "unknown";
 
@@ -32,6 +33,8 @@ std::optional<OutputType> ParseOutputType(const std::string& type)
         return OutputType::BECH32;
     } else if (type == OUTPUT_TYPE_STRING_BECH32M) {
         return OutputType::BECH32M;
+    } else if (type == OUTPUT_TYPE_STRING_BLSCT) {
+        return OutputType::BLSCT;
     }
     return std::nullopt;
 }
@@ -43,6 +46,7 @@ const std::string& FormatOutputType(OutputType type)
     case OutputType::P2SH_SEGWIT: return OUTPUT_TYPE_STRING_P2SH_SEGWIT;
     case OutputType::BECH32: return OUTPUT_TYPE_STRING_BECH32;
     case OutputType::BECH32M: return OUTPUT_TYPE_STRING_BECH32M;
+    case OutputType::BLSCT: return OUTPUT_TYPE_STRING_BLSCT;
     case OutputType::UNKNOWN: return OUTPUT_TYPE_STRING_UNKNOWN;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
@@ -63,8 +67,12 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
             return witdest;
         }
     }
+    case OutputType::BLSCT: {
+        return CNoDestination();
+    }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should never be used with BECH32M or UNKNOWN, so let it assert
+    case OutputType::UNKNOWN: {
+    } // This function should never be used with BECH32M, BLSCT or UNKNOWN, so let it assert
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -103,12 +111,15 @@ CTxDestination AddAndGetDestinationForScript(FillableSigningProvider& keystore, 
         }
     }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should not be used for BECH32M or UNKNOWN, so let it assert
+    case OutputType::BLSCT:
+    case OutputType::UNKNOWN: {
+    } // This function should not be used for BECH32M or UNKNOWN, so let it assert
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
 
-std::optional<OutputType> OutputTypeFromDestination(const CTxDestination& dest) {
+std::optional<OutputType> OutputTypeFromDestination(const CTxDestination& dest)
+{
     if (std::holds_alternative<PKHash>(dest) ||
         std::holds_alternative<ScriptHash>(dest)) {
         return OutputType::LEGACY;

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -19,6 +19,7 @@ enum class OutputType {
     P2SH_SEGWIT,
     BECH32,
     BECH32M,
+    BLSCT,
     UNKNOWN,
 };
 
@@ -26,6 +27,7 @@ static constexpr auto OUTPUT_TYPES = std::array{
     OutputType::LEGACY,
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
+    OutputType::BLSCT,
     OutputType::BECH32M,
 };
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -174,6 +174,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblockstats", 1, "stats" },
     { "pruneblockchain", 0, "height" },
     { "keypoolrefill", 0, "newsize" },
+    { "keypoolrefill", 1, "blsct" },
     { "getrawmempool", 0, "verbose" },
     { "getrawmempool", 1, "mempool_sequence" },
     { "estimatesmartfee", 0, "conf_target" },
@@ -265,7 +266,7 @@ UniValue ParseNonRFCJSONValue(std::string_view raw)
     return parsed;
 }
 
-UniValue RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams)
+UniValue RPCConvertValues(const std::string& strMethod, const std::vector<std::string>& strParams)
 {
     UniValue params(UniValue::VARR);
 
@@ -277,12 +278,12 @@ UniValue RPCConvertValues(const std::string &strMethod, const std::vector<std::s
     return params;
 }
 
-UniValue RPCConvertNamedValues(const std::string &strMethod, const std::vector<std::string> &strParams)
+UniValue RPCConvertNamedValues(const std::string& strMethod, const std::vector<std::string>& strParams)
 {
     UniValue params(UniValue::VOBJ);
     UniValue positional_args{UniValue::VARR};
 
-    for (std::string_view s: strParams) {
+    for (std::string_view s : strParams) {
         size_t pos = s.find('=');
         if (pos == std::string::npos) {
             positional_args.push_back(rpcCvtTable.ArgToUniValue(s, strMethod, positional_args.size()));
@@ -290,7 +291,7 @@ UniValue RPCConvertNamedValues(const std::string &strMethod, const std::vector<s
         }
 
         std::string name{s.substr(0, pos)};
-        std::string_view value{s.substr(pos+1)};
+        std::string_view value{s.substr(pos + 1)};
 
         // Intentionally overwrite earlier named values with later ones as a
         // convenience for scripts and command line users that want to merge

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -11,7 +11,7 @@
 
 const SigningProvider& DUMMY_SIGNING_PROVIDER = SigningProvider();
 
-template<typename M, typename K, typename V>
+template <typename M, typename K, typename V>
 bool LookupHelper(const M& map, const K& key, V& value)
 {
     auto it = map.find(key);
@@ -110,7 +110,7 @@ void FillableSigningProvider::ImplicitlyLearnRelatedKeyScripts(const CPubKey& pu
     }
 }
 
-bool FillableSigningProvider::GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const
+bool FillableSigningProvider::GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const
 {
     CKey key;
     if (!GetKey(address, key)) {
@@ -120,7 +120,7 @@ bool FillableSigningProvider::GetPubKey(const CKeyID &address, CPubKey &vchPubKe
     return true;
 }
 
-bool FillableSigningProvider::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
+bool FillableSigningProvider::AddKeyPubKey(const CKey& key, const CPubKey& pubkey)
 {
     LOCK(cs_KeyStore);
     mapKeys[pubkey.GetID()] = key;
@@ -128,7 +128,7 @@ bool FillableSigningProvider::AddKeyPubKey(const CKey& key, const CPubKey &pubke
     return true;
 }
 
-bool FillableSigningProvider::HaveKey(const CKeyID &address) const
+bool FillableSigningProvider::HaveKey(const CKeyID& address) const
 {
     LOCK(cs_KeyStore);
     return mapKeys.count(address) > 0;
@@ -144,7 +144,7 @@ std::set<CKeyID> FillableSigningProvider::GetKeys() const
     return set_address;
 }
 
-bool FillableSigningProvider::GetKey(const CKeyID &address, CKey &keyOut) const
+bool FillableSigningProvider::GetKey(const CKeyID& address, CKey& keyOut) const
 {
     LOCK(cs_KeyStore);
     KeyMap::const_iterator mi = mapKeys.find(address);
@@ -181,12 +181,11 @@ std::set<CScriptID> FillableSigningProvider::GetCScripts() const
     return set_script;
 }
 
-bool FillableSigningProvider::GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const
+bool FillableSigningProvider::GetCScript(const CScriptID& hash, CScript& redeemScriptOut) const
 {
     LOCK(cs_KeyStore);
     ScriptMap::const_iterator mi = mapScripts.find(hash);
-    if (mi != mapScripts.end())
-    {
+    if (mi != mapScripts.end()) {
         redeemScriptOut = (*mi).second;
         return true;
     }
@@ -216,10 +215,7 @@ CKeyID GetKeyForDestination(const SigningProvider& store, const CTxDestination& 
     if (auto output_key = std::get_if<WitnessV1Taproot>(&dest)) {
         TaprootSpendData spenddata;
         CPubKey pub;
-        if (store.GetTaprootSpendData(*output_key, spenddata)
-            && !spenddata.internal_key.IsNull()
-            && spenddata.merkle_root.IsNull()
-            && store.GetPubKeyByXOnly(spenddata.internal_key, pub)) {
+        if (store.GetTaprootSpendData(*output_key, spenddata) && !spenddata.internal_key.IsNull() && spenddata.merkle_root.IsNull() && store.GetPubKeyByXOnly(spenddata.internal_key, pub)) {
             return pub.GetID();
         }
     }

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -215,7 +215,10 @@ CKeyID GetKeyForDestination(const SigningProvider& store, const CTxDestination& 
     if (auto output_key = std::get_if<WitnessV1Taproot>(&dest)) {
         TaprootSpendData spenddata;
         CPubKey pub;
-        if (store.GetTaprootSpendData(*output_key, spenddata) && !spenddata.internal_key.IsNull() && spenddata.merkle_root.IsNull() && store.GetPubKeyByXOnly(spenddata.internal_key, pub)) {
+        if (store.GetTaprootSpendData(*output_key, spenddata)
+            && !spenddata.internal_key.IsNull()
+            && spenddata.merkle_root.IsNull()
+            && store.GetPubKeyByXOnly(spenddata.internal_key, pub)) {
             return pub.GetID();
         }
     }

--- a/src/test/blsct/arith/mcl/mcl_g1point_tests.cpp
+++ b/src/test/blsct/arith/mcl/mcl_g1point_tests.cpp
@@ -218,6 +218,18 @@ BOOST_AUTO_TEST_CASE(test_is_zero)
     BOOST_CHECK_EQUAL(p.IsZero(), true);
 }
 
+BOOST_AUTO_TEST_CASE(test_infinity)
+{
+    auto g = MclG1Point::GetInfinity();
+    BOOST_CHECK_EQUAL(g.IsZero(), true);
+
+    auto p = MclG1Point::GetBasePoint();
+    BOOST_CHECK_EQUAL(p.IsZero(), false);
+
+    auto q = p + g;
+    BOOST_CHECK_EQUAL(q == p, true);
+}
+
 BOOST_AUTO_TEST_CASE(test_get_set_vch)
 {
     MclG1Point p(uint256::ONE);
@@ -226,7 +238,7 @@ BOOST_AUTO_TEST_CASE(test_get_set_vch)
     MclG1Point q;
     BOOST_CHECK(p != q);
 
-    q.SetVch(vec);
+    BOOST_CHECK(q.SetVch(vec) == true);
     BOOST_CHECK(p == q);
 }
 

--- a/src/test/blsct/arith/mcl/mcl_g1point_tests.cpp
+++ b/src/test/blsct/arith/mcl/mcl_g1point_tests.cpp
@@ -223,6 +223,15 @@ BOOST_AUTO_TEST_CASE(test_infinity)
     auto g = MclG1Point::GetInfinity();
     BOOST_CHECK_EQUAL(g.IsZero(), true);
 
+    mclBnG1 g0;
+    auto g_str = "0"s;
+    if (mclBnG1_setStr(&g0, g_str.c_str(), g_str.length(), 10) == -1) {
+        throw std::runtime_error("MclG1Point::GetInfinity(): mclBnG1_setStr failed");
+    }
+    MclG1Point g0p(g0);
+
+    BOOST_CHECK(g == g0p);
+
     auto p = MclG1Point::GetBasePoint();
     BOOST_CHECK_EQUAL(p.IsZero(), false);
 

--- a/src/test/blsct/sign_verify_tests.cpp
+++ b/src/test/blsct/sign_verify_tests.cpp
@@ -5,13 +5,13 @@
 #define BOOST_UNIT_TEST
 #define BLS_ETH 1
 
-#include <boost/test/unit_test.hpp>
-#include <test/util/setup_common.h>
-#include <util/strencodings.h>
+#include <blsct/common.h>
 #include <blsct/private_key.h>
 #include <blsct/public_key.h>
 #include <blsct/public_keys.h>
-#include <blsct/common.h>
+#include <boost/test/unit_test.hpp>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
 
 namespace blsct {
 
@@ -28,8 +28,7 @@ BOOST_AUTO_TEST_CASE(test_compatibility_bet_bls_keys_and_blsct_keys)
 
     // public key
     blsct::PublicKey blsct_pk = blsct_sk.GetPublicKey();
-    MclG1Point blsct_g1_point;
-    blsct_pk.GetG1Point(blsct_g1_point);
+    MclG1Point blsct_g1_point = blsct_pk.GetG1Point();
 
     blsPublicKey bls_pk;
     blsGetPublicKey(&bls_pk, &bls_sk);
@@ -54,11 +53,11 @@ BOOST_AUTO_TEST_CASE(test_sign_verify_balance_batch)
     blsct::PrivateKey sk1(1);
     blsct::PrivateKey sk2(12345);
 
-    std::vector<blsct::Signature> sigs {
+    std::vector<blsct::Signature> sigs{
         sk1.SignBalance(),
         sk2.SignBalance(),
     };
-    PublicKeys pks(std::vector<blsct::PublicKey> {
+    PublicKeys pks(std::vector<blsct::PublicKey>{
         sk1.GetPublicKey(),
         sk2.GetPublicKey(),
     });
@@ -70,17 +69,17 @@ BOOST_AUTO_TEST_CASE(test_sign_verify_balance_batch)
 
 BOOST_AUTO_TEST_CASE(test_sign_verify_balance_batch_bad_inputs)
 {
-    PublicKeys pks(std::vector<blsct::PublicKey> {});
+    PublicKeys pks(std::vector<blsct::PublicKey>{});
     blsct::Signature aggr_sig;
     BOOST_CHECK_THROW(pks.VerifyBalanceBatch(aggr_sig), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(test_augment_message)
 {
-    std::vector<uint8_t> pk_data(blsct::PublicKey::SIZE);
-    auto pk = blsct::PublicKey(pk_data);
-    auto msg = std::vector<uint8_t> { 1, 2, 3, 4, 5 };
-    auto act = pk.AugmentMessage(msg);
+    auto pk = MclG1Point::GetBasePoint();
+    std::vector<uint8_t> pk_data = pk.GetVch();
+    auto msg = std::vector<uint8_t>{1, 2, 3, 4, 5};
+    auto act = PublicKey(pk).AugmentMessage(msg);
 
     auto exp = std::vector<uint8_t>(pk_data);
     exp.insert(exp.end(), msg.begin(), msg.end());
@@ -91,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test_sign_verify)
 {
     blsct::PrivateKey sk(1);
     auto pk = sk.GetPublicKey();
-    std::vector<uint8_t> msg {'m', 's', 'g'};
+    std::vector<uint8_t> msg{'m', 's', 'g'};
 
     auto sig = sk.Sign(msg);
     auto res = pk.Verify(msg, sig);
@@ -103,15 +102,15 @@ BOOST_AUTO_TEST_CASE(test_verify_batch)
     blsct::PrivateKey sk1(1);
     blsct::PrivateKey sk2(12345);
 
-    PublicKeys pks(std::vector<blsct::PublicKey> {
+    PublicKeys pks(std::vector<blsct::PublicKey>{
         sk1.GetPublicKey(),
         sk2.GetPublicKey(),
     });
-    std::vector<std::vector<uint8_t>> msgs {
-        std::vector<uint8_t> {'m', 's', 'g', '1'},
-        std::vector<uint8_t> {'m', 's', 'g', '2'},
+    std::vector<std::vector<uint8_t>> msgs{
+        std::vector<uint8_t>{'m', 's', 'g', '1'},
+        std::vector<uint8_t>{'m', 's', 'g', '2'},
     };
-    std::vector<blsct::Signature> sigs {
+    std::vector<blsct::Signature> sigs{
         sk1.Sign(msgs[0]),
         sk2.Sign(msgs[1]),
     };
@@ -126,15 +125,15 @@ BOOST_AUTO_TEST_CASE(test_verify_batch_bad_inputs)
     blsct::Signature sig;
     {
         // empty pks
-        PublicKeys empty_pks(std::vector<PublicKey> {});
-        std::vector<std::vector<uint8_t>> msgs {
-            std::vector<uint8_t> {'m', 's', 'g'},
+        PublicKeys empty_pks(std::vector<PublicKey>{});
+        std::vector<std::vector<uint8_t>> msgs{
+            std::vector<uint8_t>{'m', 's', 'g'},
         };
         BOOST_CHECK_THROW(empty_pks.VerifyBatch(msgs, sig), std::runtime_error);
     }
     {
         // empty msgs
-        PublicKeys pks(std::vector<PublicKey> {
+        PublicKeys pks(std::vector<PublicKey>{
             PublicKey(),
         });
         std::vector<std::vector<uint8_t>> empty_msgs;
@@ -142,12 +141,12 @@ BOOST_AUTO_TEST_CASE(test_verify_batch_bad_inputs)
     }
     {
         // numbers of pks and msgs don't match
-        PublicKeys pks(std::vector<PublicKey> {
+        PublicKeys pks(std::vector<PublicKey>{
             PublicKey(),
         });
-        std::vector<std::vector<uint8_t>> msgs {
-            std::vector<uint8_t> {'m', 's', 'g', '1'},
-            std::vector<uint8_t> {'m', 's', 'g', '2'},
+        std::vector<std::vector<uint8_t>> msgs{
+            std::vector<uint8_t>{'m', 's', 'g', '1'},
+            std::vector<uint8_t>{'m', 's', 'g', '2'},
         };
         BOOST_CHECK_THROW(pks.VerifyBatch(msgs, sig), std::runtime_error);
     }
@@ -155,4 +154,4 @@ BOOST_AUTO_TEST_CASE(test_verify_batch_bad_inputs)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-}
+} // namespace blsct

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -16,370 +16,354 @@
 namespace wallet {
 RPCHelpMan getnewaddress()
 {
-    return RPCHelpMan{"getnewaddress",
-                "\nReturns a new Bitcoin address for receiving payments.\n"
-                "If 'label' is specified, it is added to the address book \n"
-                "so payments received with the address will be associated with 'label'.\n",
-                {
-                    {"label", RPCArg::Type::STR, RPCArg::Default{""}, "The label name for the address to be linked to. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name."},
-                    {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\"."},
-                },
-                RPCResult{
-                    RPCResult::Type::STR, "address", "The new bitcoin address"
-                },
-                RPCExamples{
-                    HelpExampleCli("getnewaddress", "")
-            + HelpExampleRpc("getnewaddress", "")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+    return RPCHelpMan{
+        "getnewaddress",
+        "\nReturns a new Bitcoin address for receiving payments.\n"
+        "If 'label' is specified, it is added to the address book \n"
+        "so payments received with the address will be associated with 'label'.\n",
+        {
+            {"label", RPCArg::Type::STR, RPCArg::Default{""}, "The label name for the address to be linked to. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name."},
+            {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are \"blsct\", \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\"."},
+        },
+        RPCResult{
+            RPCResult::Type::STR, "address", "The new bitcoin address"},
+        RPCExamples{
+            HelpExampleCli("getnewaddress", "") + HelpExampleRpc("getnewaddress", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
+            LOCK(pwallet->cs_wallet);
 
-    if (!pwallet->CanGetAddresses()) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Error: This wallet has no available keys");
-    }
+            if (!pwallet->CanGetAddresses()) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error: This wallet has no available keys");
+            }
 
-    // Parse the label first so we don't generate a key if there's an error
-    const std::string label{LabelFromValue(request.params[0])};
+            // Parse the label first so we don't generate a key if there's an error
+            const std::string label{LabelFromValue(request.params[0])};
 
-    OutputType output_type = pwallet->m_default_address_type;
-    if (!request.params[1].isNull()) {
-        std::optional<OutputType> parsed = ParseOutputType(request.params[1].get_str());
-        if (!parsed) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[1].get_str()));
-        } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
-        }
-        output_type = parsed.value();
-    }
+            OutputType output_type = pwallet->m_default_address_type;
+            if (!request.params[1].isNull()) {
+                std::optional<OutputType> parsed = ParseOutputType(request.params[1].get_str());
+                if (!parsed) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[1].get_str()));
+                } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
+                }
+                output_type = parsed.value();
+            }
 
-    auto op_dest = pwallet->GetNewDestination(output_type, label);
-    if (!op_dest) {
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
-    }
+            auto op_dest = pwallet->GetNewDestination(output_type, label);
+            if (!op_dest) {
+                throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
+            }
 
-    return EncodeDestination(*op_dest);
-},
+            return EncodeDestination(*op_dest);
+        },
     };
 }
 
 RPCHelpMan getrawchangeaddress()
 {
-    return RPCHelpMan{"getrawchangeaddress",
-                "\nReturns a new Bitcoin address, for receiving change.\n"
-                "This is for use with raw transactions, NOT normal use.\n",
-                {
-                    {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -changetype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\"."},
-                },
-                RPCResult{
-                    RPCResult::Type::STR, "address", "The address"
-                },
-                RPCExamples{
-                    HelpExampleCli("getrawchangeaddress", "")
-            + HelpExampleRpc("getrawchangeaddress", "")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+    return RPCHelpMan{
+        "getrawchangeaddress",
+        "\nReturns a new Bitcoin address, for receiving change.\n"
+        "This is for use with raw transactions, NOT normal use.\n",
+        {
+            {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -changetype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\"."},
+        },
+        RPCResult{
+            RPCResult::Type::STR, "address", "The address"},
+        RPCExamples{
+            HelpExampleCli("getrawchangeaddress", "") + HelpExampleRpc("getrawchangeaddress", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
+            LOCK(pwallet->cs_wallet);
 
-    if (!pwallet->CanGetAddresses(true)) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Error: This wallet has no available keys");
-    }
+            if (!pwallet->CanGetAddresses(true)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error: This wallet has no available keys");
+            }
 
-    OutputType output_type = pwallet->m_default_change_type.value_or(pwallet->m_default_address_type);
-    if (!request.params[0].isNull()) {
-        std::optional<OutputType> parsed = ParseOutputType(request.params[0].get_str());
-        if (!parsed) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[0].get_str()));
-        } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
-        }
-        output_type = parsed.value();
-    }
+            OutputType output_type = pwallet->m_default_change_type.value_or(pwallet->m_default_address_type);
+            if (!request.params[0].isNull()) {
+                std::optional<OutputType> parsed = ParseOutputType(request.params[0].get_str());
+                if (!parsed) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[0].get_str()));
+                } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
+                }
+                output_type = parsed.value();
+            }
 
-    auto op_dest = pwallet->GetNewChangeDestination(output_type);
-    if (!op_dest) {
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
-    }
-    return EncodeDestination(*op_dest);
-},
+            auto op_dest = pwallet->GetNewChangeDestination(output_type);
+            if (!op_dest) {
+                throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
+            }
+            return EncodeDestination(*op_dest);
+        },
     };
 }
 
 
 RPCHelpMan setlabel()
 {
-    return RPCHelpMan{"setlabel",
-                "\nSets the label associated with the given address.\n",
-                {
-                    {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitcoin address to be associated with a label."},
-                    {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The label to assign to the address."},
-                },
-                RPCResult{RPCResult::Type::NONE, "", ""},
-                RPCExamples{
-                    HelpExampleCli("setlabel", "\"" + EXAMPLE_ADDRESS[0] + "\" \"tabby\"")
-            + HelpExampleRpc("setlabel", "\"" + EXAMPLE_ADDRESS[0] + "\", \"tabby\"")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+    return RPCHelpMan{
+        "setlabel",
+        "\nSets the label associated with the given address.\n",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitcoin address to be associated with a label."},
+            {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The label to assign to the address."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("setlabel", "\"" + EXAMPLE_ADDRESS[0] + "\" \"tabby\"") + HelpExampleRpc("setlabel", "\"" + EXAMPLE_ADDRESS[0] + "\", \"tabby\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
+            LOCK(pwallet->cs_wallet);
 
-    CTxDestination dest = DecodeDestination(request.params[0].get_str());
-    if (!IsValidDestination(dest)) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
-    }
+            CTxDestination dest = DecodeDestination(request.params[0].get_str());
+            if (!IsValidDestination(dest)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+            }
 
-    const std::string label{LabelFromValue(request.params[1])};
+            const std::string label{LabelFromValue(request.params[1])};
 
-    if (pwallet->IsMine(dest)) {
-        pwallet->SetAddressBook(dest, label, AddressPurpose::RECEIVE);
-    } else {
-        pwallet->SetAddressBook(dest, label, AddressPurpose::SEND);
-    }
+            if (pwallet->IsMine(dest)) {
+                pwallet->SetAddressBook(dest, label, AddressPurpose::RECEIVE);
+            } else {
+                pwallet->SetAddressBook(dest, label, AddressPurpose::SEND);
+            }
 
-    return UniValue::VNULL;
-},
+            return UniValue::VNULL;
+        },
     };
 }
 
 RPCHelpMan listaddressgroupings()
 {
-    return RPCHelpMan{"listaddressgroupings",
-                "\nLists groups of addresses which have had their common ownership\n"
-                "made public by common use as inputs or as the resulting change\n"
-                "in past transactions\n",
-                {},
-                RPCResult{
-                    RPCResult::Type::ARR, "", "",
+    return RPCHelpMan{
+        "listaddressgroupings",
+        "\nLists groups of addresses which have had their common ownership\n"
+        "made public by common use as inputs or as the resulting change\n"
+        "in past transactions\n",
+        {},
+        RPCResult{
+            RPCResult::Type::ARR, "", "", {
+                                              {RPCResult::Type::ARR, "", "", {
+                                                                                 {RPCResult::Type::ARR_FIXED, "", "", {
+                                                                                                                          {RPCResult::Type::STR, "address", "The bitcoin address"},
+                                                                                                                          {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT},
+                                                                                                                          {RPCResult::Type::STR, "label", /*optional=*/true, "The label"},
+                                                                                                                      }},
+                                                                             }},
+                                          }},
+        RPCExamples{HelpExampleCli("listaddressgroupings", "") + HelpExampleRpc("listaddressgroupings", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+
+            // Make sure the results are valid at least up to the most recent block
+            // the user could have gotten from another RPC command prior to now
+            pwallet->BlockUntilSyncedToCurrentChain();
+
+            LOCK(pwallet->cs_wallet);
+
+            UniValue jsonGroupings(UniValue::VARR);
+            std::map<CTxDestination, CAmount> balances = GetAddressBalances(*pwallet);
+            for (const std::set<CTxDestination>& grouping : GetAddressGroupings(*pwallet)) {
+                UniValue jsonGrouping(UniValue::VARR);
+                for (const CTxDestination& address : grouping) {
+                    UniValue addressInfo(UniValue::VARR);
+                    addressInfo.push_back(EncodeDestination(address));
+                    addressInfo.push_back(ValueFromAmount(balances[address]));
                     {
-                        {RPCResult::Type::ARR, "", "",
-                        {
-                            {RPCResult::Type::ARR_FIXED, "", "",
-                            {
-                                {RPCResult::Type::STR, "address", "The bitcoin address"},
-                                {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT},
-                                {RPCResult::Type::STR, "label", /*optional=*/true, "The label"},
-                            }},
-                        }},
+                        const auto* address_book_entry = pwallet->FindAddressBookEntry(address);
+                        if (address_book_entry) {
+                            addressInfo.push_back(address_book_entry->GetLabel());
+                        }
                     }
-                },
-                RPCExamples{
-                    HelpExampleCli("listaddressgroupings", "")
-            + HelpExampleRpc("listaddressgroupings", "")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
-
-    LOCK(pwallet->cs_wallet);
-
-    UniValue jsonGroupings(UniValue::VARR);
-    std::map<CTxDestination, CAmount> balances = GetAddressBalances(*pwallet);
-    for (const std::set<CTxDestination>& grouping : GetAddressGroupings(*pwallet)) {
-        UniValue jsonGrouping(UniValue::VARR);
-        for (const CTxDestination& address : grouping)
-        {
-            UniValue addressInfo(UniValue::VARR);
-            addressInfo.push_back(EncodeDestination(address));
-            addressInfo.push_back(ValueFromAmount(balances[address]));
-            {
-                const auto* address_book_entry = pwallet->FindAddressBookEntry(address);
-                if (address_book_entry) {
-                    addressInfo.push_back(address_book_entry->GetLabel());
+                    jsonGrouping.push_back(addressInfo);
                 }
+                jsonGroupings.push_back(jsonGrouping);
             }
-            jsonGrouping.push_back(addressInfo);
-        }
-        jsonGroupings.push_back(jsonGrouping);
-    }
-    return jsonGroupings;
-},
+            return jsonGroupings;
+        },
     };
 }
 
 RPCHelpMan addmultisigaddress()
 {
-    return RPCHelpMan{"addmultisigaddress",
-                "\nAdd an nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup.\n"
-                "Each key is a Bitcoin address or hex-encoded public key.\n"
-                "This functionality is only intended for use with non-watchonly addresses.\n"
-                "See `importaddress` for watchonly p2sh address support.\n"
-                "If 'label' is specified, assign address to that label.\n"
-                "Note: This command is only compatible with legacy wallets.\n",
+    return RPCHelpMan{
+        "addmultisigaddress",
+        "\nAdd an nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup.\n"
+        "Each key is a Bitcoin address or hex-encoded public key.\n"
+        "This functionality is only intended for use with non-watchonly addresses.\n"
+        "See `importaddress` for watchonly p2sh address support.\n"
+        "If 'label' is specified, assign address to that label.\n"
+        "Note: This command is only compatible with legacy wallets.\n",
+        {
+            {"nrequired", RPCArg::Type::NUM, RPCArg::Optional::NO, "The number of required signatures out of the n keys or addresses."},
+            {
+                "keys",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::NO,
+                "The bitcoin addresses or hex-encoded public keys",
                 {
-                    {"nrequired", RPCArg::Type::NUM, RPCArg::Optional::NO, "The number of required signatures out of the n keys or addresses."},
-                    {"keys", RPCArg::Type::ARR, RPCArg::Optional::NO, "The bitcoin addresses or hex-encoded public keys",
-                        {
-                            {"key", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "bitcoin address or hex-encoded public key"},
-                        },
-                        },
-                    {"label", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A label to assign the addresses to."},
-                    {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
+                    {"key", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "bitcoin address or hex-encoded public key"},
                 },
-                RPCResult{
-                    RPCResult::Type::OBJ, "", "",
-                    {
-                        {RPCResult::Type::STR, "address", "The value of the new multisig address"},
-                        {RPCResult::Type::STR_HEX, "redeemScript", "The string value of the hex-encoded redemption script"},
-                        {RPCResult::Type::STR, "descriptor", "The descriptor for this multisig"},
-                        {RPCResult::Type::ARR, "warnings", /*optional=*/true, "Any warnings resulting from the creation of this multisig",
-                        {
-                            {RPCResult::Type::STR, "", ""},
-                        }},
-                    }
-                },
-                RPCExamples{
-            "\nAdd a multisig address from 2 addresses\n"
-            + HelpExampleCli("addmultisigaddress", "2 \"[\\\"" + EXAMPLE_ADDRESS[0] + "\\\",\\\"" + EXAMPLE_ADDRESS[1] + "\\\"]\"") +
-            "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("addmultisigaddress", "2, \"[\\\"" + EXAMPLE_ADDRESS[0] + "\\\",\\\"" + EXAMPLE_ADDRESS[1] + "\\\"]\"")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+            },
+            {"label", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A label to assign the addresses to."},
+            {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "", {
+                                              {RPCResult::Type::STR, "address", "The value of the new multisig address"},
+                                              {RPCResult::Type::STR_HEX, "redeemScript", "The string value of the hex-encoded redemption script"},
+                                              {RPCResult::Type::STR, "descriptor", "The descriptor for this multisig"},
+                                              {RPCResult::Type::ARR, "warnings", /*optional=*/true, "Any warnings resulting from the creation of this multisig", {
+                                                                                                                                                                     {RPCResult::Type::STR, "", ""},
+                                                                                                                                                                 }},
+                                          }},
+        RPCExamples{"\nAdd a multisig address from 2 addresses\n" + HelpExampleCli("addmultisigaddress", "2 \"[\\\"" + EXAMPLE_ADDRESS[0] + "\\\",\\\"" + EXAMPLE_ADDRESS[1] + "\\\"]\"") + "\nAs a JSON-RPC call\n" + HelpExampleRpc("addmultisigaddress", "2, \"[\\\"" + EXAMPLE_ADDRESS[0] + "\\\",\\\"" + EXAMPLE_ADDRESS[1] + "\\\"]\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
+            LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet);
 
-    LOCK2(pwallet->cs_wallet, spk_man.cs_KeyStore);
+            LOCK2(pwallet->cs_wallet, spk_man.cs_KeyStore);
 
-    const std::string label{LabelFromValue(request.params[2])};
+            const std::string label{LabelFromValue(request.params[2])};
 
-    int required = request.params[0].getInt<int>();
+            int required = request.params[0].getInt<int>();
 
-    // Get the public keys
-    const UniValue& keys_or_addrs = request.params[1].get_array();
-    std::vector<CPubKey> pubkeys;
-    for (unsigned int i = 0; i < keys_or_addrs.size(); ++i) {
-        if (IsHex(keys_or_addrs[i].get_str()) && (keys_or_addrs[i].get_str().length() == 66 || keys_or_addrs[i].get_str().length() == 130)) {
-            pubkeys.push_back(HexToPubKey(keys_or_addrs[i].get_str()));
-        } else {
-            pubkeys.push_back(AddrToPubKey(spk_man, keys_or_addrs[i].get_str()));
-        }
-    }
+            // Get the public keys
+            const UniValue& keys_or_addrs = request.params[1].get_array();
+            std::vector<CPubKey> pubkeys;
+            for (unsigned int i = 0; i < keys_or_addrs.size(); ++i) {
+                if (IsHex(keys_or_addrs[i].get_str()) && (keys_or_addrs[i].get_str().length() == 66 || keys_or_addrs[i].get_str().length() == 130)) {
+                    pubkeys.push_back(HexToPubKey(keys_or_addrs[i].get_str()));
+                } else {
+                    pubkeys.push_back(AddrToPubKey(spk_man, keys_or_addrs[i].get_str()));
+                }
+            }
 
-    OutputType output_type = pwallet->m_default_address_type;
-    if (!request.params[3].isNull()) {
-        std::optional<OutputType> parsed = ParseOutputType(request.params[3].get_str());
-        if (!parsed) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[3].get_str()));
-        } else if (parsed.value() == OutputType::BECH32M) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Bech32m multisig addresses cannot be created with legacy wallets");
-        }
-        output_type = parsed.value();
-    }
+            OutputType output_type = pwallet->m_default_address_type;
+            if (!request.params[3].isNull()) {
+                std::optional<OutputType> parsed = ParseOutputType(request.params[3].get_str());
+                if (!parsed) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[3].get_str()));
+                } else if (parsed.value() == OutputType::BECH32M) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Bech32m multisig addresses cannot be created with legacy wallets");
+                }
+                output_type = parsed.value();
+            }
 
-    // Construct using pay-to-script-hash:
-    CScript inner;
-    CTxDestination dest = AddAndGetMultisigDestination(required, pubkeys, output_type, spk_man, inner);
-    pwallet->SetAddressBook(dest, label, AddressPurpose::SEND);
+            // Construct using pay-to-script-hash:
+            CScript inner;
+            CTxDestination dest = AddAndGetMultisigDestination(required, pubkeys, output_type, spk_man, inner);
+            pwallet->SetAddressBook(dest, label, AddressPurpose::SEND);
 
-    // Make the descriptor
-    std::unique_ptr<Descriptor> descriptor = InferDescriptor(GetScriptForDestination(dest), spk_man);
+            // Make the descriptor
+            std::unique_ptr<Descriptor> descriptor = InferDescriptor(GetScriptForDestination(dest), spk_man);
 
-    UniValue result(UniValue::VOBJ);
-    result.pushKV("address", EncodeDestination(dest));
-    result.pushKV("redeemScript", HexStr(inner));
-    result.pushKV("descriptor", descriptor->ToString());
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("address", EncodeDestination(dest));
+            result.pushKV("redeemScript", HexStr(inner));
+            result.pushKV("descriptor", descriptor->ToString());
 
-    UniValue warnings(UniValue::VARR);
-    if (descriptor->GetOutputType() != output_type) {
-        // Only warns if the user has explicitly chosen an address type we cannot generate
-        warnings.push_back("Unable to make chosen address type, please ensure no uncompressed public keys are present.");
-    }
-    PushWarnings(warnings, result);
+            UniValue warnings(UniValue::VARR);
+            if (descriptor->GetOutputType() != output_type) {
+                // Only warns if the user has explicitly chosen an address type we cannot generate
+                warnings.push_back("Unable to make chosen address type, please ensure no uncompressed public keys are present.");
+            }
+            PushWarnings(warnings, result);
 
-    return result;
-},
+            return result;
+        },
     };
 }
 
 RPCHelpMan keypoolrefill()
 {
-    return RPCHelpMan{"keypoolrefill",
-                "\nFills the keypool."+
-        HELP_REQUIRING_PASSPHRASE,
-                {
-                    {"newsize", RPCArg::Type::NUM, RPCArg::DefaultHint{strprintf("%u, or as set by -keypool", DEFAULT_KEYPOOL_SIZE)}, "The new keypool size"},
-                },
-                RPCResult{RPCResult::Type::NONE, "", ""},
-                RPCExamples{
-                    HelpExampleCli("keypoolrefill", "")
-            + HelpExampleRpc("keypoolrefill", "")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+    return RPCHelpMan{
+        "keypoolrefill",
+        "\nFills the keypool." +
+            HELP_REQUIRING_PASSPHRASE,
+        {
+            {"newsize", RPCArg::Type::NUM, RPCArg::DefaultHint{strprintf("%u, or as set by -keypool", DEFAULT_KEYPOOL_SIZE)}, "The new keypool size"},
+            {"blsct", RPCArg::Type::BOOL, RPCArg::DefaultHint{strprintf("%u", true)}, "Whether it should fill the blsct subaddress pool"},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("keypoolrefill", "") + HelpExampleRpc("keypoolrefill", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    if (pwallet->IsLegacy() && pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Error: Private keys are disabled for this wallet");
-    }
+            if (pwallet->IsLegacy() && pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error: Private keys are disabled for this wallet");
+            }
 
-    LOCK(pwallet->cs_wallet);
+            LOCK(pwallet->cs_wallet);
 
-    // 0 is interpreted by TopUpKeyPool() as the default keypool size given by -keypool
-    unsigned int kpSize = 0;
-    if (!request.params[0].isNull()) {
-        if (request.params[0].getInt<int>() < 0)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size.");
-        kpSize = (unsigned int)request.params[0].getInt<int>();
-    }
+            // 0 is interpreted by TopUpKeyPool() as the default keypool size given by -keypool
+            unsigned int kpSize = 0;
+            if (!request.params[0].isNull()) {
+                if (request.params[0].getInt<int>() < 0)
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size.");
+                kpSize = (unsigned int)request.params[0].getInt<int>();
+            }
 
-    EnsureWalletIsUnlocked(*pwallet);
-    pwallet->TopUpKeyPool(kpSize);
+            bool fBlsct = true;
 
-    if (pwallet->GetKeyPoolSize() < kpSize) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Error refreshing keypool.");
-    }
+            if (!request.params[1].isNull()) {
+                if (!request.params[1].get_bool())
+                    fBlsct = false;
+            }
 
-    return UniValue::VNULL;
-},
+            EnsureWalletIsUnlocked(*pwallet);
+            pwallet->TopUpKeyPool(kpSize, fBlsct);
+
+            if (pwallet->GetKeyPoolSize() < kpSize) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error refreshing keypool.");
+            }
+
+            return UniValue::VNULL;
+        },
     };
 }
 
 RPCHelpMan newkeypool()
 {
-    return RPCHelpMan{"newkeypool",
-                "\nEntirely clears and refills the keypool.\n"
-                "WARNING: On non-HD wallets, this will require a new backup immediately, to include the new keys.\n"
-                "When restoring a backup of an HD wallet created before the newkeypool command is run, funds received to\n"
-                "new addresses may not appear automatically. They have not been lost, but the wallet may not find them.\n"
-                "This can be fixed by running the newkeypool command on the backup and then rescanning, so the wallet\n"
-                "re-generates the required keys." +
+    return RPCHelpMan{
+        "newkeypool",
+        "\nEntirely clears and refills the keypool.\n"
+        "WARNING: On non-HD wallets, this will require a new backup immediately, to include the new keys.\n"
+        "When restoring a backup of an HD wallet created before the newkeypool command is run, funds received to\n"
+        "new addresses may not appear automatically. They have not been lost, but the wallet may not find them.\n"
+        "This can be fixed by running the newkeypool command on the backup and then rescanning, so the wallet\n"
+        "re-generates the required keys." +
             HELP_REQUIRING_PASSPHRASE,
-                {},
-                RPCResult{RPCResult::Type::NONE, "", ""},
-                RPCExamples{
-            HelpExampleCli("newkeypool", "")
-            + HelpExampleRpc("newkeypool", "")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+        {},
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("newkeypool", "") + HelpExampleRpc("newkeypool", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
+            LOCK(pwallet->cs_wallet);
 
-    LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet, true);
-    spk_man.NewKeyPool();
+            LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*pwallet, true);
+            spk_man.NewKeyPool();
 
-    return UniValue::VNULL;
-},
+            return UniValue::VNULL;
+        },
     };
 }
 
@@ -387,7 +371,7 @@ RPCHelpMan newkeypool()
 class DescribeWalletAddressVisitor
 {
 public:
-    const SigningProvider * const provider;
+    const SigningProvider* const provider;
 
     void ProcessSubScript(const CScript& subscript, UniValue& obj) const
     {
@@ -471,7 +455,8 @@ public:
         }
         return obj;
     }
-    UniValue operator()(const blsct::DoublePublicKey& id) const {
+    UniValue operator()(const blsct::DoublePublicKey& id) const
+    {
         UniValue obj(UniValue::VOBJ);
         CPubKey vchPubKey;
         obj.pushKV("viewKey", HexStr(id.GetVkVch()));
@@ -496,261 +481,240 @@ static UniValue DescribeWalletAddress(const CWallet& wallet, const CTxDestinatio
 
 RPCHelpMan getaddressinfo()
 {
-    return RPCHelpMan{"getaddressinfo",
-                "\nReturn information about the given bitcoin address.\n"
-                "Some of the information will only be present if the address is in the active wallet.\n",
-                {
-                    {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitcoin address for which to get information."},
-                },
-                RPCResult{
-                    RPCResult::Type::OBJ, "", "",
-                    {
-                        {RPCResult::Type::STR, "address", "The bitcoin address validated."},
-                        {RPCResult::Type::STR_HEX, "scriptPubKey", "The hex-encoded scriptPubKey generated by the address."},
-                        {RPCResult::Type::BOOL, "ismine", "If the address is yours."},
-                        {RPCResult::Type::BOOL, "iswatchonly", "If the address is watchonly."},
-                        {RPCResult::Type::BOOL, "solvable", "If we know how to spend coins sent to this address, ignoring the possible lack of private keys."},
-                        {RPCResult::Type::STR, "desc", /*optional=*/true, "A descriptor for spending coins sent to this address (only when solvable)."},
-                        {RPCResult::Type::STR, "parent_desc", /*optional=*/true, "The descriptor used to derive this address if this is a descriptor wallet"},
-                        {RPCResult::Type::BOOL, "isscript", "If the key is a script."},
-                        {RPCResult::Type::BOOL, "ischange", "If the address was used for change output."},
-                        {RPCResult::Type::BOOL, "iswitness", "If the address is a witness address."},
-                        {RPCResult::Type::NUM, "witness_version", /*optional=*/true, "The version number of the witness program."},
-                        {RPCResult::Type::STR_HEX, "witness_program", /*optional=*/true, "The hex value of the witness program."},
-                        {RPCResult::Type::STR, "script", /*optional=*/true, "The output script type. Only if isscript is true and the redeemscript is known. Possible\n"
-                                                                     "types: nonstandard, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_keyhash,\n"
-                            "witness_v0_scripthash, witness_unknown."},
-                        {RPCResult::Type::STR_HEX, "hex", /*optional=*/true, "The redeemscript for the p2sh address."},
-                        {RPCResult::Type::ARR, "pubkeys", /*optional=*/true, "Array of pubkeys associated with the known redeemscript (only if script is multisig).",
-                        {
-                            {RPCResult::Type::STR, "pubkey", ""},
-                        }},
-                        {RPCResult::Type::NUM, "sigsrequired", /*optional=*/true, "The number of signatures required to spend multisig output (only if script is multisig)."},
-                        {RPCResult::Type::STR_HEX, "pubkey", /*optional=*/true, "The hex value of the raw public key for single-key addresses (possibly embedded in P2SH or P2WSH)."},
-                        {RPCResult::Type::OBJ, "embedded", /*optional=*/true, "Information about the address embedded in P2SH or P2WSH, if relevant and known.",
-                        {
-                            {RPCResult::Type::ELISION, "", "Includes all getaddressinfo output fields for the embedded address, excluding metadata (timestamp, hdkeypath, hdseedid)\n"
-                            "and relation to the wallet (ismine, iswatchonly)."},
-                        }},
-                        {RPCResult::Type::BOOL, "iscompressed", /*optional=*/true, "If the pubkey is compressed."},
-                        {RPCResult::Type::NUM_TIME, "timestamp", /*optional=*/true, "The creation time of the key, if available, expressed in " + UNIX_EPOCH_TIME + "."},
-                        {RPCResult::Type::STR, "hdkeypath", /*optional=*/true, "The HD keypath, if the key is HD and available."},
-                        {RPCResult::Type::STR_HEX, "hdseedid", /*optional=*/true, "The Hash160 of the HD seed."},
-                        {RPCResult::Type::STR_HEX, "hdmasterfingerprint", /*optional=*/true, "The fingerprint of the master key."},
-                        {RPCResult::Type::ARR, "labels", "Array of labels associated with the address. Currently limited to one label but returned\n"
-                            "as an array to keep the API stable if multiple labels are enabled in the future.",
-                        {
-                            {RPCResult::Type::STR, "label name", "Label name (defaults to \"\")."},
-                        }},
-                    }
-                },
-                RPCExamples{
-                    HelpExampleCli("getaddressinfo", "\"" + EXAMPLE_ADDRESS[0] + "\"") +
-                    HelpExampleRpc("getaddressinfo", "\"" + EXAMPLE_ADDRESS[0] + "\"")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+    return RPCHelpMan{
+        "getaddressinfo",
+        "\nReturn information about the given bitcoin address.\n"
+        "Some of the information will only be present if the address is in the active wallet.\n",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitcoin address for which to get information."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "", {
+                                              {RPCResult::Type::STR, "address", "The bitcoin address validated."},
+                                              {RPCResult::Type::STR_HEX, "scriptPubKey", "The hex-encoded scriptPubKey generated by the address."},
+                                              {RPCResult::Type::BOOL, "ismine", "If the address is yours."},
+                                              {RPCResult::Type::BOOL, "iswatchonly", "If the address is watchonly."},
+                                              {RPCResult::Type::BOOL, "solvable", "If we know how to spend coins sent to this address, ignoring the possible lack of private keys."},
+                                              {RPCResult::Type::STR, "desc", /*optional=*/true, "A descriptor for spending coins sent to this address (only when solvable)."},
+                                              {RPCResult::Type::STR, "parent_desc", /*optional=*/true, "The descriptor used to derive this address if this is a descriptor wallet"},
+                                              {RPCResult::Type::BOOL, "isscript", /*optional=*/true, "If the key is a script."},
+                                              {RPCResult::Type::BOOL, "isblsct", /*optional=*/true, "If the address is of type blsct."},
+                                              {RPCResult::Type::STR_HEX, "spendKey", /*optional=*/true, "The spending key of the address."},
+                                              {RPCResult::Type::STR_HEX, "viewKey", /*optional=*/true, "The view key of the address."},
+                                              {RPCResult::Type::BOOL, "ischange", "If the address was used for change output."},
+                                              {RPCResult::Type::BOOL, "iswitness", /*optional=*/true, "If the address is a witness address."},
+                                              {RPCResult::Type::NUM, "witness_version", /*optional=*/true, "The version number of the witness program."},
+                                              {RPCResult::Type::STR_HEX, "witness_program", /*optional=*/true, "The hex value of the witness program."},
+                                              {RPCResult::Type::STR, "script", /*optional=*/true, "The output script type. Only if isscript is true and the redeemscript is known. Possible\n"
+                                                                                                  "types: nonstandard, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_keyhash,\n"
+                                                                                                  "witness_v0_scripthash, witness_unknown."},
+                                              {RPCResult::Type::STR_HEX, "hex", /*optional=*/true, "The redeemscript for the p2sh address."},
+                                              {RPCResult::Type::ARR, "pubkeys", /*optional=*/true, "Array of pubkeys associated with the known redeemscript (only if script is multisig).", {
+                                                                                                                                                                                                {RPCResult::Type::STR, "pubkey", ""},
+                                                                                                                                                                                            }},
+                                              {RPCResult::Type::NUM, "sigsrequired", /*optional=*/true, "The number of signatures required to spend multisig output (only if script is multisig)."},
+                                              {RPCResult::Type::STR_HEX, "pubkey", /*optional=*/true, "The hex value of the raw public key for single-key addresses (possibly embedded in P2SH or P2WSH)."},
+                                              {RPCResult::Type::OBJ, "embedded", /*optional=*/true, "Information about the address embedded in P2SH or P2WSH, if relevant and known.", {
+                                                                                                                                                                                           {RPCResult::Type::ELISION, "", "Includes all getaddressinfo output fields for the embedded address, excluding metadata (timestamp, hdkeypath, hdseedid)\n"
+                                                                                                                                                                                                                          "and relation to the wallet (ismine, iswatchonly)."},
+                                                                                                                                                                                       }},
+                                              {RPCResult::Type::BOOL, "iscompressed", /*optional=*/true, "If the pubkey is compressed."},
+                                              {RPCResult::Type::NUM_TIME, "timestamp", /*optional=*/true, "The creation time of the key, if available, expressed in " + UNIX_EPOCH_TIME + "."},
+                                              {RPCResult::Type::STR, "hdkeypath", /*optional=*/true, "The HD keypath, if the key is HD and available."},
+                                              {RPCResult::Type::STR_HEX, "hdseedid", /*optional=*/true, "The Hash160 of the HD seed."},
+                                              {RPCResult::Type::STR_HEX, "hdmasterfingerprint", /*optional=*/true, "The fingerprint of the master key."},
+                                              {RPCResult::Type::ARR, "labels", "Array of labels associated with the address. Currently limited to one label but returned\n"
+                                                                               "as an array to keep the API stable if multiple labels are enabled in the future.",
+                                               {
+                                                   {RPCResult::Type::STR, "label name", "Label name (defaults to \"\")."},
+                                               }},
+                                          }},
+        RPCExamples{HelpExampleCli("getaddressinfo", "\"" + EXAMPLE_ADDRESS[0] + "\"") + HelpExampleRpc("getaddressinfo", "\"" + EXAMPLE_ADDRESS[0] + "\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
+            LOCK(pwallet->cs_wallet);
 
-    std::string error_msg;
-    CTxDestination dest = DecodeDestination(request.params[0].get_str(), error_msg);
+            std::string error_msg;
+            CTxDestination dest = DecodeDestination(request.params[0].get_str(), error_msg);
 
-    // Make sure the destination is valid
-    if (!IsValidDestination(dest)) {
-        // Set generic error message in case 'DecodeDestination' didn't set it
-        if (error_msg.empty()) error_msg = "Invalid address";
+            // Make sure the destination is valid
+            if (!IsValidDestination(dest)) {
+                // Set generic error message in case 'DecodeDestination' didn't set it
+                if (error_msg.empty()) error_msg = "Invalid address";
 
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error_msg);
-    }
-
-    UniValue ret(UniValue::VOBJ);
-
-    std::string currentAddress = EncodeDestination(dest);
-    ret.pushKV("address", currentAddress);
-
-    CScript scriptPubKey = GetScriptForDestination(dest);
-    ret.pushKV("scriptPubKey", HexStr(scriptPubKey));
-
-    std::unique_ptr<SigningProvider> provider = pwallet->GetSolvingProvider(scriptPubKey);
-
-    isminetype mine = pwallet->IsMine(dest);
-    ret.pushKV("ismine", bool(mine & ISMINE_SPENDABLE));
-
-    if (provider) {
-        auto inferred = InferDescriptor(scriptPubKey, *provider);
-        bool solvable = inferred->IsSolvable();
-        ret.pushKV("solvable", solvable);
-        if (solvable) {
-            ret.pushKV("desc", inferred->ToString());
-        }
-    } else {
-        ret.pushKV("solvable", false);
-    }
-
-    const auto& spk_mans = pwallet->GetScriptPubKeyMans(scriptPubKey);
-    // In most cases there is only one matching ScriptPubKey manager and we can't resolve ambiguity in a better way
-    ScriptPubKeyMan* spk_man{nullptr};
-    if (spk_mans.size()) spk_man = *spk_mans.begin();
-
-    DescriptorScriptPubKeyMan* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
-    if (desc_spk_man) {
-        std::string desc_str;
-        if (desc_spk_man->GetDescriptorString(desc_str, /*priv=*/false)) {
-            ret.pushKV("parent_desc", desc_str);
-        }
-    }
-
-    ret.pushKV("iswatchonly", bool(mine & ISMINE_WATCH_ONLY));
-
-    UniValue detail = DescribeWalletAddress(*pwallet, dest);
-    ret.pushKVs(detail);
-
-    ret.pushKV("ischange", ScriptIsChange(*pwallet, scriptPubKey));
-
-    if (spk_man) {
-        if (const std::unique_ptr<CKeyMetadata> meta = spk_man->GetMetadata(dest)) {
-            ret.pushKV("timestamp", meta->nCreateTime);
-            if (meta->has_key_origin) {
-                // In legacy wallets hdkeypath has always used an apostrophe for
-                // hardened derivation. Perhaps some external tool depends on that.
-                ret.pushKV("hdkeypath", WriteHDKeypath(meta->key_origin.path, /*apostrophe=*/!desc_spk_man));
-                ret.pushKV("hdseedid", meta->hd_seed_id.GetHex());
-                ret.pushKV("hdmasterfingerprint", HexStr(meta->key_origin.fingerprint));
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error_msg);
             }
-        }
-    }
 
-    // Return a `labels` array containing the label associated with the address,
-    // equivalent to the `label` field above. Currently only one label can be
-    // associated with an address, but we return an array so the API remains
-    // stable if we allow multiple labels to be associated with an address in
-    // the future.
-    UniValue labels(UniValue::VARR);
-    const auto* address_book_entry = pwallet->FindAddressBookEntry(dest);
-    if (address_book_entry) {
-        labels.push_back(address_book_entry->GetLabel());
-    }
-    ret.pushKV("labels", std::move(labels));
+            UniValue ret(UniValue::VOBJ);
 
-    return ret;
-},
+            std::string currentAddress = EncodeDestination(dest);
+            ret.pushKV("address", currentAddress);
+
+            CScript scriptPubKey = GetScriptForDestination(dest);
+            ret.pushKV("scriptPubKey", HexStr(scriptPubKey));
+
+            std::unique_ptr<SigningProvider> provider = pwallet->GetSolvingProvider(scriptPubKey);
+
+            isminetype mine = pwallet->IsMine(dest);
+            ret.pushKV("ismine", bool(mine & ISMINE_SPENDABLE));
+
+            if (provider) {
+                auto inferred = InferDescriptor(scriptPubKey, *provider);
+                bool solvable = inferred->IsSolvable();
+                ret.pushKV("solvable", solvable);
+                if (solvable) {
+                    ret.pushKV("desc", inferred->ToString());
+                }
+            } else {
+                ret.pushKV("solvable", false);
+            }
+
+            const auto& spk_mans = pwallet->GetScriptPubKeyMans(scriptPubKey);
+            // In most cases there is only one matching ScriptPubKey manager and we can't resolve ambiguity in a better way
+            ScriptPubKeyMan* spk_man{nullptr};
+            if (spk_mans.size()) spk_man = *spk_mans.begin();
+
+            DescriptorScriptPubKeyMan* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
+            if (desc_spk_man) {
+                std::string desc_str;
+                if (desc_spk_man->GetDescriptorString(desc_str, /*priv=*/false)) {
+                    ret.pushKV("parent_desc", desc_str);
+                }
+            }
+
+            ret.pushKV("iswatchonly", bool(mine & ISMINE_WATCH_ONLY));
+
+            UniValue detail = DescribeWalletAddress(*pwallet, dest);
+            ret.pushKVs(detail);
+
+            ret.pushKV("ischange", ScriptIsChange(*pwallet, scriptPubKey));
+
+            if (spk_man) {
+                if (const std::unique_ptr<CKeyMetadata> meta = spk_man->GetMetadata(dest)) {
+                    ret.pushKV("timestamp", meta->nCreateTime);
+                    if (meta->has_key_origin) {
+                        // In legacy wallets hdkeypath has always used an apostrophe for
+                        // hardened derivation. Perhaps some external tool depends on that.
+                        ret.pushKV("hdkeypath", WriteHDKeypath(meta->key_origin.path, /*apostrophe=*/!desc_spk_man));
+                        ret.pushKV("hdseedid", meta->hd_seed_id.GetHex());
+                        ret.pushKV("hdmasterfingerprint", HexStr(meta->key_origin.fingerprint));
+                    }
+                }
+            }
+
+            // Return a `labels` array containing the label associated with the address,
+            // equivalent to the `label` field above. Currently only one label can be
+            // associated with an address, but we return an array so the API remains
+            // stable if we allow multiple labels to be associated with an address in
+            // the future.
+            UniValue labels(UniValue::VARR);
+            const auto* address_book_entry = pwallet->FindAddressBookEntry(dest);
+            if (address_book_entry) {
+                labels.push_back(address_book_entry->GetLabel());
+            }
+            ret.pushKV("labels", std::move(labels));
+
+            return ret;
+        },
     };
 }
 
 RPCHelpMan getaddressesbylabel()
 {
-    return RPCHelpMan{"getaddressesbylabel",
-                "\nReturns the list of addresses assigned the specified label.\n",
-                {
-                    {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The label."},
-                },
-                RPCResult{
-                    RPCResult::Type::OBJ_DYN, "", "json object with addresses as keys",
-                    {
-                        {RPCResult::Type::OBJ, "address", "json object with information about address",
-                        {
-                            {RPCResult::Type::STR, "purpose", "Purpose of address (\"send\" for sending address, \"receive\" for receiving address)"},
-                        }},
-                    }
-                },
-                RPCExamples{
-                    HelpExampleCli("getaddressesbylabel", "\"tabby\"")
-            + HelpExampleRpc("getaddressesbylabel", "\"tabby\"")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
+    return RPCHelpMan{
+        "getaddressesbylabel",
+        "\nReturns the list of addresses assigned the specified label.\n",
+        {
+            {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The label."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ_DYN, "", "json object with addresses as keys", {
+                                                                                    {RPCResult::Type::OBJ, "address", "json object with information about address", {
+                                                                                                                                                                        {RPCResult::Type::STR, "purpose", "Purpose of address (\"send\" for sending address, \"receive\" for receiving address)"},
+                                                                                                                                                                    }},
+                                                                                }},
+        RPCExamples{HelpExampleCli("getaddressesbylabel", "\"tabby\"") + HelpExampleRpc("getaddressesbylabel", "\"tabby\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
+            LOCK(pwallet->cs_wallet);
 
-    const std::string label{LabelFromValue(request.params[0])};
+            const std::string label{LabelFromValue(request.params[0])};
 
-    // Find all addresses that have the given label
-    UniValue ret(UniValue::VOBJ);
-    std::set<std::string> addresses;
-    pwallet->ForEachAddrBookEntry([&](const CTxDestination& _dest, const std::string& _label, bool _is_change, const std::optional<AddressPurpose>& _purpose) {
-        if (_is_change) return;
-        if (_label == label) {
-            std::string address = EncodeDestination(_dest);
-            // CWallet::m_address_book is not expected to contain duplicate
-            // address strings, but build a separate set as a precaution just in
-            // case it does.
-            bool unique = addresses.emplace(address).second;
-            CHECK_NONFATAL(unique);
-            // UniValue::pushKV checks if the key exists in O(N)
-            // and since duplicate addresses are unexpected (checked with
-            // std::set in O(log(N))), UniValue::__pushKV is used instead,
-            // which currently is O(1).
-            UniValue value(UniValue::VOBJ);
-            value.pushKV("purpose", _purpose ? PurposeToString(*_purpose) : "unknown");
-            ret.__pushKV(address, value);
-        }
-    });
+            // Find all addresses that have the given label
+            UniValue ret(UniValue::VOBJ);
+            std::set<std::string> addresses;
+            pwallet->ForEachAddrBookEntry([&](const CTxDestination& _dest, const std::string& _label, bool _is_change, const std::optional<AddressPurpose>& _purpose) {
+                if (_is_change) return;
+                if (_label == label) {
+                    std::string address = EncodeDestination(_dest);
+                    // CWallet::m_address_book is not expected to contain duplicate
+                    // address strings, but build a separate set as a precaution just in
+                    // case it does.
+                    bool unique = addresses.emplace(address).second;
+                    CHECK_NONFATAL(unique);
+                    // UniValue::pushKV checks if the key exists in O(N)
+                    // and since duplicate addresses are unexpected (checked with
+                    // std::set in O(log(N))), UniValue::__pushKV is used instead,
+                    // which currently is O(1).
+                    UniValue value(UniValue::VOBJ);
+                    value.pushKV("purpose", _purpose ? PurposeToString(*_purpose) : "unknown");
+                    ret.__pushKV(address, value);
+                }
+            });
 
-    if (ret.empty()) {
-        throw JSONRPCError(RPC_WALLET_INVALID_LABEL_NAME, std::string("No addresses with label " + label));
-    }
+            if (ret.empty()) {
+                throw JSONRPCError(RPC_WALLET_INVALID_LABEL_NAME, std::string("No addresses with label " + label));
+            }
 
-    return ret;
-},
+            return ret;
+        },
     };
 }
 
 RPCHelpMan listlabels()
 {
-    return RPCHelpMan{"listlabels",
-                "\nReturns the list of all labels, or labels that are assigned to addresses with a specific purpose.\n",
-                {
-                    {"purpose", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address purpose to list labels for ('send','receive'). An empty string is the same as not providing this argument."},
-                },
-                RPCResult{
-                    RPCResult::Type::ARR, "", "",
-                    {
-                        {RPCResult::Type::STR, "label", "Label name"},
+    return RPCHelpMan{
+        "listlabels",
+        "\nReturns the list of all labels, or labels that are assigned to addresses with a specific purpose.\n",
+        {
+            {"purpose", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address purpose to list labels for ('send','receive'). An empty string is the same as not providing this argument."},
+        },
+        RPCResult{
+            RPCResult::Type::ARR, "", "", {
+                                              {RPCResult::Type::STR, "label", "Label name"},
+                                          }},
+        RPCExamples{"\nList all labels\n" + HelpExampleCli("listlabels", "") + "\nList labels that have receiving addresses\n" + HelpExampleCli("listlabels", "receive") + "\nList labels that have sending addresses\n" + HelpExampleCli("listlabels", "send") + "\nAs a JSON-RPC call\n" + HelpExampleRpc("listlabels", "receive")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+            if (!pwallet) return UniValue::VNULL;
+
+            LOCK(pwallet->cs_wallet);
+
+            std::optional<AddressPurpose> purpose;
+            if (!request.params[0].isNull()) {
+                std::string purpose_str = request.params[0].get_str();
+                if (!purpose_str.empty()) {
+                    purpose = PurposeFromString(purpose_str);
+                    if (!purpose) {
+                        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid 'purpose' argument, must be a known purpose string, typically 'send', or 'receive'.");
                     }
-                },
-                RPCExamples{
-            "\nList all labels\n"
-            + HelpExampleCli("listlabels", "") +
-            "\nList labels that have receiving addresses\n"
-            + HelpExampleCli("listlabels", "receive") +
-            "\nList labels that have sending addresses\n"
-            + HelpExampleCli("listlabels", "send") +
-            "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("listlabels", "receive")
-                },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-{
-    const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return UniValue::VNULL;
-
-    LOCK(pwallet->cs_wallet);
-
-    std::optional<AddressPurpose> purpose;
-    if (!request.params[0].isNull()) {
-        std::string purpose_str = request.params[0].get_str();
-        if (!purpose_str.empty()) {
-            purpose = PurposeFromString(purpose_str);
-            if (!purpose) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid 'purpose' argument, must be a known purpose string, typically 'send', or 'receive'.");
+                }
             }
-        }
-    }
 
-    // Add to a set to sort by label name, then insert into Univalue array
-    std::set<std::string> label_set = pwallet->ListAddrBookLabels(purpose);
+            // Add to a set to sort by label name, then insert into Univalue array
+            std::set<std::string> label_set = pwallet->ListAddrBookLabels(purpose);
 
-    UniValue ret(UniValue::VARR);
-    for (const std::string& name : label_set) {
-        ret.push_back(name);
-    }
+            UniValue ret(UniValue::VARR);
+            for (const std::string& name : label_set) {
+                ret.push_back(name);
+            }
 
-    return ret;
-},
+            return ret;
+        },
     };
 }
 
@@ -765,14 +729,11 @@ RPCHelpMan walletdisplayaddress()
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "bitcoin address to display"},
         },
         RPCResult{
-            RPCResult::Type::OBJ,"","",
-            {
-                {RPCResult::Type::STR, "address", "The address as confirmed by the signer"},
-            }
-        },
+            RPCResult::Type::OBJ, "", "", {
+                                              {RPCResult::Type::STR, "address", "The address as confirmed by the signer"},
+                                          }},
         RPCExamples{""},
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-        {
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
             if (!wallet) return UniValue::VNULL;
             CWallet* const pwallet = wallet.get();
@@ -793,8 +754,7 @@ RPCHelpMan walletdisplayaddress()
             UniValue result(UniValue::VOBJ);
             result.pushKV("address", request.params[0].get_str());
             return result;
-        }
-    };
+        }};
 }
 #endif // ENABLE_EXTERNAL_SIGNER
 } // namespace wallet

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -52,8 +52,7 @@ namespace {
  * distinguish between top-level scriptPubKey execution and P2SH redeemScript
  * execution (a distinction that has no impact on consensus rules).
  */
-enum class IsMineSigVersion
-{
+enum class IsMineSigVersion {
     TOP = 0,        //!< scriptPubKey execution
     P2SH = 1,       //!< P2SH redeemScript
     WITNESS_V0 = 2, //!< P2WSH witness script execution
@@ -64,8 +63,7 @@ enum class IsMineSigVersion
  * Its order is significant, as we return the max of all explored
  * possibilities.
  */
-enum class IsMineResult
-{
+enum class IsMineResult {
     NO = 0,         //!< Not ours
     WATCH_ONLY = 1, //!< Included in watch-only balance
     SPENDABLE = 2,  //!< Included in all balances
@@ -94,7 +92,7 @@ bool HaveKeys(const std::vector<valtype>& pubkeys, const LegacyScriptPubKeyMan& 
 //! @param recurse_scripthash  whether to recurse into nested p2sh and p2wsh
 //!                            scripts or simply treat any script that has been
 //!                            stored in the keystore as spendable
-IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& scriptPubKey, IsMineSigVersion sigversion, bool recurse_scripthash=true)
+IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& scriptPubKey, IsMineSigVersion sigversion, bool recurse_scripthash = true)
 {
     IsMineResult ret = IsMineResult::NO;
 
@@ -117,8 +115,7 @@ IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& s
             ret = std::max(ret, IsMineResult::SPENDABLE);
         }
         break;
-    case TxoutType::WITNESS_V0_KEYHASH:
-    {
+    case TxoutType::WITNESS_V0_KEYHASH: {
         if (sigversion == IsMineSigVersion::WITNESS_V0) {
             // P2WPKH inside P2WSH is invalid.
             return IsMineResult::INVALID;
@@ -144,8 +141,7 @@ IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& s
             ret = std::max(ret, IsMineResult::SPENDABLE);
         }
         break;
-    case TxoutType::SCRIPTHASH:
-    {
+    case TxoutType::SCRIPTHASH: {
         if (sigversion != IsMineSigVersion::TOP) {
             // P2SH inside P2WSH or P2SH is invalid.
             return IsMineResult::INVALID;
@@ -157,8 +153,7 @@ IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& s
         }
         break;
     }
-    case TxoutType::WITNESS_V0_SCRIPTHASH:
-    {
+    case TxoutType::WITNESS_V0_SCRIPTHASH: {
         if (sigversion == IsMineSigVersion::WITNESS_V0) {
             // P2WSH inside P2WSH is invalid.
             return IsMineResult::INVALID;
@@ -174,8 +169,7 @@ IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& s
         break;
     }
 
-    case TxoutType::MULTISIG:
-    {
+    case TxoutType::MULTISIG: {
         // Never treat bare multisig outputs as ours (they can still be made watchonly-though)
         if (sigversion == IsMineSigVersion::TOP) {
             break;
@@ -186,7 +180,7 @@ IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& s
         // partially owned (somebody else has a key that can spend
         // them) enable spend-out-from-under-you attacks, especially
         // in shared-wallet situations.
-        std::vector<valtype> keys(vSolutions.begin()+1, vSolutions.begin()+vSolutions.size()-1);
+        std::vector<valtype> keys(vSolutions.begin() + 1, vSolutions.begin() + vSolutions.size() - 1);
         if (!PermitsUncompressed(sigversion)) {
             for (size_t i = 0; i < keys.size(); i++) {
                 if (keys[i].size() != 33) {
@@ -233,13 +227,11 @@ bool LegacyScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key
         bool keyFail = false;
         CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
         WalletBatch batch(m_storage.GetDatabase());
-        for (; mi != mapCryptedKeys.end(); ++mi)
-        {
-            const CPubKey &vchPubKey = (*mi).second.first;
-            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
+        for (; mi != mapCryptedKeys.end(); ++mi) {
+            const CPubKey& vchPubKey = (*mi).second.first;
+            const std::vector<unsigned char>& vchCryptedSecret = (*mi).second.second;
             CKey key;
-            if (!DecryptKey(master_key, vchCryptedSecret, vchPubKey, key))
-            {
+            if (!DecryptKey(master_key, vchCryptedSecret, vchPubKey, key)) {
                 keyFail = true;
                 break;
             }
@@ -251,8 +243,7 @@ bool LegacyScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key
                 batch.WriteCryptedKey(vchPubKey, vchCryptedSecret, mapKeyMetadata[vchPubKey.GetID()]);
             }
         }
-        if (keyPass && keyFail)
-        {
+        if (keyPass && keyFail) {
             LogPrintf("The wallet is probably corrupted: Some keys decrypt but not all.\n");
             throw std::runtime_error("Error unlocking wallet: some keys decrypt but not all. Your wallet file may be corrupt.");
         }
@@ -274,9 +265,8 @@ bool LegacyScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, WalletBat
 
     KeyMap keys_to_encrypt;
     keys_to_encrypt.swap(mapKeys); // Clear mapKeys so AddCryptedKeyInner will succeed.
-    for (const KeyMap::value_type& mKey : keys_to_encrypt)
-    {
-        const CKey &key = mKey.second;
+    for (const KeyMap::value_type& mKey : keys_to_encrypt) {
+        const CKey& key = mKey.second;
         CPubKey vchPubKey = key.GetPubKey();
         CKeyingMaterial vchSecret(key.begin(), key.end());
         std::vector<unsigned char> vchCryptedSecret;
@@ -361,7 +351,7 @@ std::vector<WalletDestination> LegacyScriptPubKeyMan::MarkUnusedAddresses(const 
         // Find the key's metadata and check if it's seed id (if it has one) is inactive, i.e. it is not the current m_hd_chain seed id.
         // If so, TopUp the inactive hd chain
         auto it = mapKeyMetadata.find(keyid);
-        if (it != mapKeyMetadata.end()){
+        if (it != mapKeyMetadata.end()) {
             CKeyMetadata meta = it->second;
             if (!meta.hd_seed_id.IsNull() && meta.hd_seed_id != m_hd_chain.seed_id) {
                 std::vector<uint32_t> path;
@@ -526,7 +516,8 @@ void LegacyScriptPubKeyMan::RewriteDB()
     // that requires a new key.
 }
 
-static int64_t GetOldestKeyTimeInPool(const std::set<int64_t>& setKeyPool, WalletBatch& batch) {
+static int64_t GetOldestKeyTimeInPool(const std::set<int64_t>& setKeyPool, WalletBatch& batch)
+{
     if (setKeyPool.empty()) {
         return GetTime();
     }
@@ -712,12 +703,12 @@ void LegacyScriptPubKeyMan::UpdateTimeFirstKey(int64_t nCreateTime)
     }
 }
 
-bool LegacyScriptPubKeyMan::LoadKey(const CKey& key, const CPubKey &pubkey)
+bool LegacyScriptPubKeyMan::LoadKey(const CKey& key, const CPubKey& pubkey)
 {
     return AddKeyPubKeyInner(key, pubkey);
 }
 
-bool LegacyScriptPubKeyMan::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
+bool LegacyScriptPubKeyMan::AddKeyPubKey(const CKey& secret, const CPubKey& pubkey)
 {
     LOCK(cs_KeyStore);
     WalletBatch batch(m_storage.GetDatabase());
@@ -757,8 +748,8 @@ bool LegacyScriptPubKeyMan::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& s
 
     if (!m_storage.HasEncryptionKeys()) {
         return batch.WriteKey(pubkey,
-                                                 secret.GetPrivKey(),
-                                                 mapKeyMetadata[pubkey.GetID()]);
+                              secret.GetPrivKey(),
+                              mapKeyMetadata[pubkey.GetID()]);
     }
     m_storage.UnsetBlankWalletFlag(batch);
     return true;
@@ -769,8 +760,7 @@ bool LegacyScriptPubKeyMan::LoadCScript(const CScript& redeemScript)
     /* A sanity check was added in pull #3843 to avoid adding redeemScripts
      * that never can be redeemed. However, old wallets may still contain
      * these. Do not add them to the wallet and warn. */
-    if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
-    {
+    if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE) {
         std::string strAddr = EncodeDestination(ScriptHash(redeemScript));
         WalletLogPrintf("%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n", __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
         return true;
@@ -793,7 +783,7 @@ void LegacyScriptPubKeyMan::LoadScriptMetadata(const CScriptID& script_id, const
     m_script_metadata[script_id] = meta;
 }
 
-bool LegacyScriptPubKeyMan::AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey)
+bool LegacyScriptPubKeyMan::AddKeyPubKeyInner(const CKey& key, const CPubKey& pubkey)
 {
     LOCK(cs_KeyStore);
     if (!m_storage.HasEncryptionKeys()) {
@@ -816,7 +806,7 @@ bool LegacyScriptPubKeyMan::AddKeyPubKeyInner(const CKey& key, const CPubKey &pu
     return true;
 }
 
-bool LegacyScriptPubKeyMan::LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, bool checksum_valid)
+bool LegacyScriptPubKeyMan::LoadCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, bool checksum_valid)
 {
     // Set fDecryptionThoroughlyChecked to false when the checksum is invalid
     if (!checksum_valid) {
@@ -826,7 +816,7 @@ bool LegacyScriptPubKeyMan::LoadCryptedKey(const CPubKey &vchPubKey, const std::
     return AddCryptedKeyInner(vchPubKey, vchCryptedSecret);
 }
 
-bool LegacyScriptPubKeyMan::AddCryptedKeyInner(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret)
+bool LegacyScriptPubKeyMan::AddCryptedKeyInner(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret)
 {
     LOCK(cs_KeyStore);
     assert(mapKeys.empty());
@@ -836,8 +826,8 @@ bool LegacyScriptPubKeyMan::AddCryptedKeyInner(const CPubKey &vchPubKey, const s
     return true;
 }
 
-bool LegacyScriptPubKeyMan::AddCryptedKey(const CPubKey &vchPubKey,
-                            const std::vector<unsigned char> &vchCryptedSecret)
+bool LegacyScriptPubKeyMan::AddCryptedKey(const CPubKey& vchPubKey,
+                                          const std::vector<unsigned char>& vchCryptedSecret)
 {
     if (!AddCryptedKeyInner(vchPubKey, vchCryptedSecret))
         return false;
@@ -845,16 +835,14 @@ bool LegacyScriptPubKeyMan::AddCryptedKey(const CPubKey &vchPubKey,
         LOCK(cs_KeyStore);
         if (encrypted_batch)
             return encrypted_batch->WriteCryptedKey(vchPubKey,
-                                                        vchCryptedSecret,
-                                                        mapKeyMetadata[vchPubKey.GetID()]);
+                                                    vchCryptedSecret,
+                                                    mapKeyMetadata[vchPubKey.GetID()]);
         else
-            return WalletBatch(m_storage.GetDatabase()).WriteCryptedKey(vchPubKey,
-                                                            vchCryptedSecret,
-                                                            mapKeyMetadata[vchPubKey.GetID()]);
+            return WalletBatch(m_storage.GetDatabase()).WriteCryptedKey(vchPubKey, vchCryptedSecret, mapKeyMetadata[vchPubKey.GetID()]);
     }
 }
 
-bool LegacyScriptPubKeyMan::HaveWatchOnly(const CScript &dest) const
+bool LegacyScriptPubKeyMan::HaveWatchOnly(const CScript& dest) const
 {
     LOCK(cs_KeyStore);
     return setWatchOnly.count(dest) > 0;
@@ -866,14 +854,14 @@ bool LegacyScriptPubKeyMan::HaveWatchOnly() const
     return (!setWatchOnly.empty());
 }
 
-static bool ExtractPubKey(const CScript &dest, CPubKey& pubKeyOut)
+static bool ExtractPubKey(const CScript& dest, CPubKey& pubKeyOut)
 {
     std::vector<std::vector<unsigned char>> solutions;
     return Solver(dest, solutions) == TxoutType::PUBKEY &&
-        (pubKeyOut = CPubKey(solutions[0])).IsFullyValid();
+           (pubKeyOut = CPubKey(solutions[0])).IsFullyValid();
 }
 
-bool LegacyScriptPubKeyMan::RemoveWatchOnly(const CScript &dest)
+bool LegacyScriptPubKeyMan::RemoveWatchOnly(const CScript& dest)
 {
     {
         LOCK(cs_KeyStore);
@@ -894,12 +882,12 @@ bool LegacyScriptPubKeyMan::RemoveWatchOnly(const CScript &dest)
     return true;
 }
 
-bool LegacyScriptPubKeyMan::LoadWatchOnly(const CScript &dest)
+bool LegacyScriptPubKeyMan::LoadWatchOnly(const CScript& dest)
 {
     return AddWatchOnlyInMem(dest);
 }
 
-bool LegacyScriptPubKeyMan::AddWatchOnlyInMem(const CScript &dest)
+bool LegacyScriptPubKeyMan::AddWatchOnlyInMem(const CScript& dest)
 {
     LOCK(cs_KeyStore);
     setWatchOnly.insert(dest);
@@ -911,7 +899,7 @@ bool LegacyScriptPubKeyMan::AddWatchOnlyInMem(const CScript &dest)
     return true;
 }
 
-bool LegacyScriptPubKeyMan::AddWatchOnlyWithDB(WalletBatch &batch, const CScript& dest)
+bool LegacyScriptPubKeyMan::AddWatchOnlyWithDB(WalletBatch& batch, const CScript& dest)
 {
     if (!AddWatchOnlyInMem(dest))
         return false;
@@ -925,7 +913,7 @@ bool LegacyScriptPubKeyMan::AddWatchOnlyWithDB(WalletBatch &batch, const CScript
     return false;
 }
 
-bool LegacyScriptPubKeyMan::AddWatchOnlyWithDB(WalletBatch &batch, const CScript& dest, int64_t create_time)
+bool LegacyScriptPubKeyMan::AddWatchOnlyWithDB(WalletBatch& batch, const CScript& dest, int64_t create_time)
 {
     m_script_metadata[CScriptID(dest)].nCreateTime = create_time;
     return AddWatchOnlyWithDB(batch, dest);
@@ -971,7 +959,7 @@ void LegacyScriptPubKeyMan::AddInactiveHDChain(const CHDChain& chain)
     m_inactive_hd_chains[chain.seed_id] = chain;
 }
 
-bool LegacyScriptPubKeyMan::HaveKey(const CKeyID &address) const
+bool LegacyScriptPubKeyMan::HaveKey(const CKeyID& address) const
 {
     LOCK(cs_KeyStore);
     if (!m_storage.HasEncryptionKeys()) {
@@ -980,7 +968,7 @@ bool LegacyScriptPubKeyMan::HaveKey(const CKeyID &address) const
     return mapCryptedKeys.count(address) > 0;
 }
 
-bool LegacyScriptPubKeyMan::GetKey(const CKeyID &address, CKey& keyOut) const
+bool LegacyScriptPubKeyMan::GetKey(const CKeyID& address, CKey& keyOut) const
 {
     LOCK(cs_KeyStore);
     if (!m_storage.HasEncryptionKeys()) {
@@ -988,10 +976,9 @@ bool LegacyScriptPubKeyMan::GetKey(const CKeyID &address, CKey& keyOut) const
     }
 
     CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
-    if (mi != mapCryptedKeys.end())
-    {
-        const CPubKey &vchPubKey = (*mi).second.first;
-        const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
+    if (mi != mapCryptedKeys.end()) {
+        const CPubKey& vchPubKey = (*mi).second.first;
+        const std::vector<unsigned char>& vchCryptedSecret = (*mi).second.second;
         return DecryptKey(m_storage.GetEncryptionKey(), vchCryptedSecret, vchPubKey, keyOut);
     }
     return false;
@@ -1017,7 +1004,7 @@ bool LegacyScriptPubKeyMan::GetKeyOrigin(const CKeyID& keyID, KeyOriginInfo& inf
     return true;
 }
 
-bool LegacyScriptPubKeyMan::GetWatchPubKey(const CKeyID &address, CPubKey &pubkey_out) const
+bool LegacyScriptPubKeyMan::GetWatchPubKey(const CKeyID& address, CPubKey& pubkey_out) const
 {
     LOCK(cs_KeyStore);
     WatchKeyMap::const_iterator it = mapWatchKeys.find(address);
@@ -1028,7 +1015,7 @@ bool LegacyScriptPubKeyMan::GetWatchPubKey(const CKeyID &address, CPubKey &pubke
     return false;
 }
 
-bool LegacyScriptPubKeyMan::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
+bool LegacyScriptPubKeyMan::GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const
 {
     LOCK(cs_KeyStore);
     if (!m_storage.HasEncryptionKeys()) {
@@ -1039,8 +1026,7 @@ bool LegacyScriptPubKeyMan::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyO
     }
 
     CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
-    if (mi != mapCryptedKeys.end())
-    {
+    if (mi != mapCryptedKeys.end()) {
         vchPubKeyOut = (*mi).second.first;
         return true;
     }
@@ -1048,7 +1034,7 @@ bool LegacyScriptPubKeyMan::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyO
     return GetWatchPubKey(address, vchPubKeyOut);
 }
 
-CPubKey LegacyScriptPubKeyMan::GenerateNewKey(WalletBatch &batch, CHDChain& hd_chain, bool internal)
+CPubKey LegacyScriptPubKeyMan::GenerateNewKey(WalletBatch& batch, CHDChain& hd_chain, bool internal)
 {
     assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
     assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET));
@@ -1086,24 +1072,27 @@ CPubKey LegacyScriptPubKeyMan::GenerateNewKey(WalletBatch &batch, CHDChain& hd_c
 }
 
 //! Try to derive an extended key, throw if it fails.
-static void DeriveExtKey(CExtKey& key_in, unsigned int index, CExtKey& key_out) {
+static void DeriveExtKey(CExtKey& key_in, unsigned int index, CExtKey& key_out)
+{
     if (!key_in.Derive(key_out, index)) {
         throw std::runtime_error("Could not derive extended key");
     }
 }
 
-void LegacyScriptPubKeyMan::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey& secret, CHDChain& hd_chain, bool internal)
+void LegacyScriptPubKeyMan::DeriveNewChildKey(WalletBatch& batch, CKeyMetadata& metadata, CKey& secret, CHDChain& hd_chain, bool internal)
 {
     // for now we use a fixed keypath scheme of m/0'/0'/k
-    CKey seed;                     //seed (256bit)
-    CExtKey masterKey;             //hd master key
-    CExtKey accountKey;            //key at m/0'
-    CExtKey chainChildKey;         //key at m/0'/0' (external) or m/0'/1' (internal)
-    CExtKey childKey;              //key at m/0'/0'/<n>'
+    CKey seed;             // seed (256bit)
+    CExtKey masterKey;     // hd master key
+    CExtKey accountKey;    // key at m/0'
+    CExtKey chainChildKey; // key at m/0'/0' (external) or m/0'/1' (internal)
+    CExtKey childKey;      // key at m/0'/0'/<n>'
 
     // try to get the seed
-    if (!GetKey(hd_chain.seed_id, seed))
+    if (!GetKey(hd_chain.seed_id, seed)) {
+        assert(false);
         throw std::runtime_error(std::string(__func__) + ": seed not found");
+    }
 
     masterKey.SetSeed(seed);
 
@@ -1113,7 +1102,7 @@ void LegacyScriptPubKeyMan::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& 
 
     // derive m/0'/0' (external chain) OR m/0'/1' (internal chain)
     assert(internal ? m_storage.CanSupportFeature(FEATURE_HD_SPLIT) : true);
-    DeriveExtKey(accountKey, BIP32_HARDENED_KEY_LIMIT+(internal ? 1 : 0), chainChildKey);
+    DeriveExtKey(accountKey, BIP32_HARDENED_KEY_LIMIT + (internal ? 1 : 0), chainChildKey);
 
     // derive child key at next index, skip keys already known to the wallet
     do {
@@ -1127,8 +1116,7 @@ void LegacyScriptPubKeyMan::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& 
             metadata.key_origin.path.push_back(1 | BIP32_HARDENED_KEY_LIMIT);
             metadata.key_origin.path.push_back(hd_chain.nInternalChainCounter | BIP32_HARDENED_KEY_LIMIT);
             hd_chain.nInternalChainCounter++;
-        }
-        else {
+        } else {
             DeriveExtKey(chainChildKey, hd_chain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT, childKey);
             metadata.hdKeypath = "m/0'/0'/" + ToString(hd_chain.nExternalChainCounter) + "'";
             metadata.key_origin.path.push_back(0 | BIP32_HARDENED_KEY_LIMIT);
@@ -1147,7 +1135,7 @@ void LegacyScriptPubKeyMan::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& 
         throw std::runtime_error(std::string(__func__) + ": writing HD chain model failed");
 }
 
-void LegacyScriptPubKeyMan::LoadKeyPool(int64_t nIndex, const CKeyPool &keypool)
+void LegacyScriptPubKeyMan::LoadKeyPool(int64_t nIndex, const CKeyPool& keypool)
 {
     LOCK(cs_KeyStore);
     if (keypool.m_pre_split) {
@@ -1193,7 +1181,7 @@ CPubKey LegacyScriptPubKeyMan::DeriveNewSeed(const CKey& key)
     assert(key.VerifyPubKey(seed));
 
     // set the hd keypath to "s" -> Seed, refers the seed to itself
-    metadata.hdKeypath     = "s";
+    metadata.hdKeypath = "s";
     metadata.has_key_origin = false;
     metadata.hd_seed_id = seed.GetID();
 
@@ -1295,7 +1283,7 @@ bool LegacyScriptPubKeyMan::TopUpChain(CHDChain& chain, unsigned int kpSize)
     } else {
         nTargetSize = m_keypool_size;
     }
-    int64_t target = std::max((int64_t) nTargetSize, int64_t{1});
+    int64_t target = std::max((int64_t)nTargetSize, int64_t{1});
 
     // count amount of available keys (internal, external)
     // make sure the keypool of external and internal keys fits the user selected target (-keypool)
@@ -1388,7 +1376,7 @@ void LegacyScriptPubKeyMan::ReturnDestination(int64_t nIndex, bool fInternal, co
 bool LegacyScriptPubKeyMan::GetKeyFromPool(CPubKey& result, const OutputType type)
 {
     assert(type != OutputType::BECH32M);
-    if (!CanGetAddresses(/*internal=*/ false)) {
+    if (!CanGetAddresses(/*internal=*/false)) {
         return false;
     }
 
@@ -1396,10 +1384,10 @@ bool LegacyScriptPubKeyMan::GetKeyFromPool(CPubKey& result, const OutputType typ
     {
         LOCK(cs_KeyStore);
         int64_t nIndex;
-        if (!ReserveKeyFromKeyPool(nIndex, keypool, /*fRequestedInternal=*/ false) && !m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        if (!ReserveKeyFromKeyPool(nIndex, keypool, /*fRequestedInternal=*/false) && !m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
             if (m_storage.IsLocked()) return false;
             WalletBatch batch(m_storage.GetDatabase());
-            result = GenerateNewKey(batch, m_hd_chain, /*internal=*/ false);
+            result = GenerateNewKey(batch, m_hd_chain, /*internal=*/false);
             return true;
         }
         KeepDestination(nIndex, type);
@@ -1478,7 +1466,7 @@ std::vector<CKeyPool> LegacyScriptPubKeyMan::MarkReserveKeysAsUsed(int64_t keypo
     AssertLockHeld(cs_KeyStore);
     bool internal = setInternalKeyPool.count(keypool_id);
     if (!internal) assert(setExternalKeyPool.count(keypool_id) || set_pre_split_keypool.count(keypool_id));
-    std::set<int64_t> *setKeyPool = internal ? &setInternalKeyPool : (set_pre_split_keypool.empty() ? &setExternalKeyPool : &set_pre_split_keypool);
+    std::set<int64_t>* setKeyPool = internal ? &setInternalKeyPool : (set_pre_split_keypool.empty() ? &setExternalKeyPool : &set_pre_split_keypool);
     auto it = setKeyPool->begin();
 
     std::vector<CKeyPool> result;
@@ -1488,7 +1476,7 @@ std::vector<CKeyPool> LegacyScriptPubKeyMan::MarkReserveKeysAsUsed(int64_t keypo
         if (index > keypool_id) break; // set*KeyPool is ordered
 
         CKeyPool keypool;
-        if (batch.ReadPool(index, keypool)) { //TODO: This should be unnecessary
+        if (batch.ReadPool(index, keypool)) { // TODO: This should be unnecessary
             m_pool_key_to_index.erase(keypool.vchPubKey.GetID());
         }
         LearnAllRelatedScripts(keypool.vchPubKey);
@@ -2034,8 +2022,8 @@ bool DescriptorScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master
     bool keyPass = m_map_crypted_keys.empty(); // Always pass when there are no encrypted keys
     bool keyFail = false;
     for (const auto& mi : m_map_crypted_keys) {
-        const CPubKey &pubkey = mi.second.first;
-        const std::vector<unsigned char> &crypted_secret = mi.second.second;
+        const CPubKey& pubkey = mi.second.first;
+        const std::vector<unsigned char>& crypted_secret = mi.second.second;
         CKey key;
         if (!DecryptKey(master_key, crypted_secret, pubkey, key)) {
             keyFail = true;
@@ -2063,9 +2051,8 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
         return false;
     }
 
-    for (const KeyMap::value_type& key_in : m_map_keys)
-    {
-        const CKey &key = key_in.second;
+    for (const KeyMap::value_type& key_in : m_map_keys) {
+        const CKey& key = key_in.second;
         CPubKey pubkey = key.GetPubKey();
         CKeyingMaterial secret(key.begin(), key.end());
         std::vector<unsigned char> crypted_secret;
@@ -2206,7 +2193,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
     return result;
 }
 
-void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey &pubkey)
+void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey& pubkey)
 {
     LOCK(cs_desc_man);
     WalletBatch batch(m_storage.GetDatabase());
@@ -2215,7 +2202,7 @@ void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey 
     }
 }
 
-bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey)
+bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey& pubkey)
 {
     AssertLockHeld(cs_desc_man);
     assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
@@ -2280,8 +2267,9 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
         desc_prefix = "tr(" + xpub + "/86h";
         break;
     }
+    case OutputType::BLSCT:
     case OutputType::UNKNOWN: {
-        // We should never have a DescriptorScriptPubKeyMan for an UNKNOWN OutputType,
+        // We should never have a DescriptorScriptPubKeyMan for an UNKNOWN or BLSCT OutputType,
         // so if we get to this point something is wrong
         assert(false);
     }
@@ -2713,7 +2701,7 @@ void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()
     FlatSigningProvider out_keys;
     std::vector<CScript> scripts_temp;
     DescriptorCache temp_cache;
-    if (!m_wallet_descriptor.descriptor->Expand(0, provider, scripts_temp, out_keys, &temp_cache)){
+    if (!m_wallet_descriptor.descriptor->Expand(0, provider, scripts_temp, out_keys, &temp_cache)) {
         throw std::runtime_error("Unable to expand descriptor");
     }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -48,7 +48,7 @@ public:
 };
 
 //! Default for -keypool
-static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 32;
 
 std::vector<CKeyID> GetAffectedKeys(const CScript& spk, const SigningProvider& provider);
 
@@ -116,7 +116,7 @@ public:
     CKeyPool();
     CKeyPool(const CPubKey& vchPubKeyIn, bool internalIn);
 
-    template<typename Stream>
+    template <typename Stream>
     void Serialize(Stream& s) const
     {
         int nVersion = s.GetVersion();
@@ -126,7 +126,7 @@ public:
         s << nTime << vchPubKey << fInternal << m_pre_split;
     }
 
-    template<typename Stream>
+    template <typename Stream>
     void Unserialize(Stream& s)
     {
         int nVersion = s.GetVersion();
@@ -151,8 +151,7 @@ public:
     }
 };
 
-struct WalletDestination
-{
+struct WalletDestination {
     CTxDestination dest;
     std::optional<bool> internal;
 };
@@ -171,7 +170,7 @@ protected:
 
 public:
     explicit ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
-    virtual ~ScriptPubKeyMan() {};
+    virtual ~ScriptPubKeyMan(){};
     virtual util::Result<CTxDestination> GetNewDestination(const OutputType type) { return util::Error{Untranslated("Not supported")}; }
     virtual isminetype IsMine(const CScript& script) const { return ISMINE_NO; }
 
@@ -184,9 +183,9 @@ public:
     virtual void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) {}
 
     /** Fills internal address pool. Use within ScriptPubKeyMan implementations should be used sparingly and only
-      * when something from the address pool is removed, excluding GetNewDestination and GetReservedDestination.
-      * External wallet code is primarily responsible for topping up prior to fetching new addresses
-      */
+     * when something from the address pool is removed, excluding GetNewDestination and GetReservedDestination.
+     * External wallet code is primarily responsible for topping up prior to fetching new addresses
+     */
     virtual bool TopUp(unsigned int size = 0) { return false; }
 
     /** Mark unused addresses as being used
@@ -199,9 +198,9 @@ public:
     virtual std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) { return {}; }
 
     /** Sets up the key generation stuff, i.e. generates new HD seeds and sets them as active.
-      * Returns false if already setup or setup fails, true if setup is successful
-      * Set force=true to make it re-setup if already setup, used for upgrades
-      */
+     * Returns false if already setup or setup fails, true if setup is successful
+     * Set force=true to make it re-setup if already setup, used for upgrades
+     */
     virtual bool SetupGeneration(bool force = false) { return false; }
 
     /* Returns true if HD is enabled */
@@ -229,8 +228,8 @@ public:
     virtual std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const { return nullptr; }
 
     /** Whether this ScriptPubKeyMan can provide a SigningProvider (via GetSolvingProvider) that, combined with
-      * sigdata, can produce solving data.
-      */
+     * sigdata, can produce solving data.
+     */
     virtual bool CanProvide(const CScript& script, SignatureData& sigdata) { return false; }
 
     /** Creates new signatures and adds them to the transaction. Returns whether all inputs were signed */
@@ -246,20 +245,21 @@ public:
     virtual std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const { return {}; };
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template<typename... Params>
-    void WalletLogPrintf(std::string fmt, Params... parameters) const {
+    template <typename... Params>
+    void WalletLogPrintf(std::string fmt, Params... parameters) const
+    {
         LogPrintf(("%s " + fmt).c_str(), m_storage.GetDisplayName(), parameters...);
     };
 
     /** Watch-only address added */
-    boost::signals2::signal<void (bool fHaveWatchOnly)> NotifyWatchonlyChanged;
+    boost::signals2::signal<void(bool fHaveWatchOnly)> NotifyWatchonlyChanged;
 
     /** Keypool has new keys */
-    boost::signals2::signal<void ()> NotifyCanGetAddressesChanged;
+    boost::signals2::signal<void()> NotifyCanGetAddressesChanged;
 };
 
 /** OutputTypes supported by the LegacyScriptPubKeyMan */
-static const std::unordered_set<OutputType> LEGACY_OUTPUT_TYPES {
+static const std::unordered_set<OutputType> LEGACY_OUTPUT_TYPES{
     OutputType::LEGACY,
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
@@ -276,7 +276,7 @@ private:
     using WatchOnlySet = std::set<CScript>;
     using WatchKeyMap = std::map<CKeyID, CPubKey>;
 
-    WalletBatch *encrypted_batch GUARDED_BY(cs_KeyStore) = nullptr;
+    WalletBatch* encrypted_batch GUARDED_BY(cs_KeyStore) = nullptr;
 
     using CryptedKeyMap = std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char>>>;
 
@@ -289,8 +289,8 @@ private:
     //! Number of pre-generated keys/scripts (part of the look-ahead process, used to detect payments)
     int64_t m_keypool_size GUARDED_BY(cs_KeyStore){DEFAULT_KEYPOOL_SIZE};
 
-    bool AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey);
-    bool AddCryptedKeyInner(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    bool AddKeyPubKeyInner(const CKey& key, const CPubKey& pubkey);
+    bool AddCryptedKeyInner(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret);
 
     /**
      * Private version of AddWatchOnly method which does not accept a
@@ -302,13 +302,13 @@ private:
      * nTimeFirstKey more intelligently for more efficient rescans.
      */
     bool AddWatchOnly(const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
-    bool AddWatchOnlyWithDB(WalletBatch &batch, const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
-    bool AddWatchOnlyInMem(const CScript &dest);
+    bool AddWatchOnlyWithDB(WalletBatch& batch, const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
+    bool AddWatchOnlyInMem(const CScript& dest);
     //! Adds a watch-only address to the store, and saves it to disk.
-    bool AddWatchOnlyWithDB(WalletBatch &batch, const CScript& dest, int64_t create_time) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
+    bool AddWatchOnlyWithDB(WalletBatch& batch, const CScript& dest, int64_t create_time) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKeyWithDB(WalletBatch &batch,const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
+    bool AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
     void AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const bool internal, WalletBatch& batch);
 
@@ -334,7 +334,7 @@ private:
     std::map<int64_t, CKeyID> m_index_to_reserved_key;
 
     //! Fetches a key from the keypool
-    bool GetKeyFromPool(CPubKey &key, const OutputType type);
+    bool GetKeyFromPool(CPubKey& key, const OutputType type);
 
     /**
      * Reserves a key from the keypool and sets nIndex to its index
@@ -365,6 +365,7 @@ private:
     bool TopUpInactiveHDChain(const CKeyID seed_id, int64_t index, bool internal);
 
     bool TopUpChain(CHDChain& chain, unsigned int size);
+
 public:
     LegacyScriptPubKeyMan(WalletStorage& storage, int64_t keypool_size) : ScriptPubKeyMan(storage), m_keypool_size(keypool_size) {}
 
@@ -422,19 +423,19 @@ public:
     std::map<CScriptID, CKeyMetadata> m_script_metadata GUARDED_BY(cs_KeyStore);
 
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
+    bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey) override;
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
-    bool LoadKey(const CKey& key, const CPubKey &pubkey);
+    bool LoadKey(const CKey& key, const CPubKey& pubkey);
     //! Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    bool AddCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret);
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
-    bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, bool checksum_valid);
+    bool LoadCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, bool checksum_valid);
     void UpdateTimeFirstKey(int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
     //! Adds a CScript to the store
     bool LoadCScript(const CScript& redeemScript);
     //! Load metadata (used by LoadWallet)
-    void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata &metadata);
-    void LoadScriptMetadata(const CScriptID& script_id, const CKeyMetadata &metadata);
+    void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata& metadata);
+    void LoadScriptMetadata(const CScriptID& script_id, const CKeyMetadata& metadata);
     //! Generate a new key
     CPubKey GenerateNewKey(WalletBatch& batch, CHDChain& hd_chain, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
@@ -446,27 +447,27 @@ public:
     void AddInactiveHDChain(const CHDChain& chain);
 
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
-    bool LoadWatchOnly(const CScript &dest);
+    bool LoadWatchOnly(const CScript& dest);
     //! Returns whether the watch-only script is in the wallet
-    bool HaveWatchOnly(const CScript &dest) const;
+    bool HaveWatchOnly(const CScript& dest) const;
     //! Returns whether there are any watch-only things in the wallet
     bool HaveWatchOnly() const;
     //! Remove a watch only script from the keystore
-    bool RemoveWatchOnly(const CScript &dest);
+    bool RemoveWatchOnly(const CScript& dest);
     bool AddWatchOnly(const CScript& dest, int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
     //! Fetches a pubkey from mapWatchKeys if it exists there
-    bool GetWatchPubKey(const CKeyID &address, CPubKey &pubkey_out) const;
+    bool GetWatchPubKey(const CKeyID& address, CPubKey& pubkey_out) const;
 
     /* SigningProvider overrides */
-    bool HaveKey(const CKeyID &address) const override;
-    bool GetKey(const CKeyID &address, CKey& keyOut) const override;
-    bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
+    bool HaveKey(const CKeyID& address) const override;
+    bool GetKey(const CKeyID& address, CKey& keyOut) const override;
+    bool GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const override;
     bool AddCScript(const CScript& redeemScript) override;
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
 
     //! Load a keypool entry
-    void LoadKeyPool(int64_t nIndex, const CKeyPool &keypool);
+    void LoadKeyPool(int64_t nIndex, const CKeyPool& keypool);
     bool NewKeyPool();
     void MarkPreSplitKeys() EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
@@ -529,14 +530,15 @@ class LegacySigningProvider : public SigningProvider
 {
 private:
     const LegacyScriptPubKeyMan& m_spk_man;
+
 public:
     explicit LegacySigningProvider(const LegacyScriptPubKeyMan& spk_man) : m_spk_man(spk_man) {}
 
-    bool GetCScript(const CScriptID &scriptid, CScript& script) const override { return m_spk_man.GetCScript(scriptid, script); }
-    bool HaveCScript(const CScriptID &scriptid) const override { return m_spk_man.HaveCScript(scriptid); }
-    bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const override { return m_spk_man.GetPubKey(address, pubkey); }
-    bool GetKey(const CKeyID &address, CKey& key) const override { return false; }
-    bool HaveKey(const CKeyID &address) const override { return false; }
+    bool GetCScript(const CScriptID& scriptid, CScript& script) const override { return m_spk_man.GetCScript(scriptid, script); }
+    bool HaveCScript(const CScriptID& scriptid) const override { return m_spk_man.HaveCScript(scriptid); }
+    bool GetPubKey(const CKeyID& address, CPubKey& pubkey) const override { return m_spk_man.GetPubKey(address, pubkey); }
+    bool GetKey(const CKeyID& address, CKey& key) const override { return false; }
+    bool HaveKey(const CKeyID& address) const override { return false; }
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override { return m_spk_man.GetKeyOrigin(keyid, info); }
 };
 
@@ -544,7 +546,7 @@ class DescriptorScriptPubKeyMan : public ScriptPubKeyMan
 {
 private:
     using ScriptPubKeyMap = std::map<CScript, int32_t>; // Map of scripts to descriptor range index
-    using PubKeyMap = std::map<CPubKey, int32_t>; // Map of pubkeys involved in scripts to descriptor range index
+    using PubKeyMap = std::map<CPubKey, int32_t>;       // Map of pubkeys involved in scripts to descriptor range index
     using CryptedKeyMap = std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char>>>;
     using KeyMap = std::map<CKeyID, CKey>;
 
@@ -561,7 +563,7 @@ private:
     //! Number of pre-generated keys/scripts (part of the look-ahead process, used to detect payments)
     int64_t m_keypool_size GUARDED_BY(cs_desc_man){DEFAULT_KEYPOOL_SIZE};
 
-    bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     KeyMap GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
@@ -575,18 +577,20 @@ private:
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
 protected:
-  WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
+    WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
 
 public:
     DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size)
-        :   ScriptPubKeyMan(storage),
-            m_keypool_size(keypool_size),
-            m_wallet_descriptor(descriptor)
-        {}
+        : ScriptPubKeyMan(storage),
+          m_keypool_size(keypool_size),
+          m_wallet_descriptor(descriptor)
+    {
+    }
     DescriptorScriptPubKeyMan(WalletStorage& storage, int64_t keypool_size)
-        :   ScriptPubKeyMan(storage),
-            m_keypool_size(keypool_size)
-        {}
+        : ScriptPubKeyMan(storage),
+          m_keypool_size(keypool_size)
+    {
+    }
 
     mutable RecursiveMutex cs_desc_man;
 
@@ -613,9 +617,9 @@ public:
     bool SetupDescriptorGeneration(const CExtKey& master_key, OutputType addr_type, bool internal);
 
     /** Provide a descriptor at setup time
-    * Returns false if already setup or setup fails, true if setup is successful
-    */
-    bool SetupDescriptor(std::unique_ptr<Descriptor>desc);
+     * Returns false if already setup or setup fails, true if setup is successful
+     */
+    bool SetupDescriptor(std::unique_ptr<Descriptor> desc);
 
     bool HavePrivateKeys() const override;
 
@@ -646,7 +650,7 @@ public:
     bool HasWalletDescriptor(const WalletDescriptor& desc) const;
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);
     bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error);
-    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey);
+    void AddDescriptorKey(const CKey& key, const CPubKey& pubkey);
     void WriteDescriptor();
 
     WalletDescriptor GetWalletDescriptor() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <test/util/setup_common.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
-#include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -12,11 +12,13 @@ namespace wallet {
 
 BOOST_AUTO_TEST_SUITE(walletload_tests)
 
-class DummyDescriptor final : public Descriptor {
+class DummyDescriptor final : public Descriptor
+{
 private:
     std::string desc;
+
 public:
-    explicit DummyDescriptor(const std::string& descriptor) : desc(descriptor) {};
+    explicit DummyDescriptor(const std::string& descriptor) : desc(descriptor){};
     ~DummyDescriptor() = default;
 
     std::string ToString() const override { return desc; }
@@ -82,7 +84,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_verif_crypted_key_checksum, TestingSetup)
         return db;
     };
 
-    {   // Context setup.
+    { // Context setup.
         // Create and encrypt legacy wallet
         std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", CreateMockWalletDatabase()));
         LOCK(wallet->cs_wallet);
@@ -99,7 +101,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_verif_crypted_key_checksum, TestingSetup)
         wallet->Flush();
 
         DatabaseOptions options;
-        for (int i=0; i < NUMBER_OF_TESTS; i++) {
+        for (int i = 0; i < NUMBER_OF_TESTS; i++) {
             dbs.emplace_back(DuplicateMockDatabase(wallet->GetDatabase(), options));
         }
     }
@@ -204,7 +206,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_verif_crypted_blsct, TestingSetup)
         return db;
     };
 
-    {   // Context setup.
+    { // Context setup.
         // Create and encrypt blsct wallet
         std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", CreateMockWalletDatabase(options)));
         LOCK(wallet->cs_wallet);
@@ -213,7 +215,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_verif_crypted_blsct, TestingSetup)
 
         // Get the keys in the wallet before encryption
         auto masterKeysMetadata = blsct_km->GetHDChain();
-        blsct::SubAddress recvAddress = blsct_km->GetAddress();
+        blsct::SubAddress recvAddress = blsct_km->GetSubAddress();
         dest = recvAddress.GetKeys();
         viewKey = blsct_km->viewKey;
         BOOST_CHECK(viewKey.IsValid());
@@ -224,7 +226,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_verif_crypted_blsct, TestingSetup)
         BOOST_CHECK(wallet->EncryptWallet("encrypt"));
         wallet->Flush();
 
-        for (int i=0; i < NUMBER_OF_TESTS; i++) {
+        for (int i = 0; i < NUMBER_OF_TESTS; i++) {
             dbs.emplace_back(DuplicateMockDatabase(wallet->GetDatabase(), options));
         }
     }
@@ -326,7 +328,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_verif_crypted_blsct, TestingSetup)
 
         // Get the keys in the wallet before encryption
         auto masterKeysMetadata = blsct_km->GetHDChain();
-        blsct::SubAddress recvAddress = blsct_km->GetAddress();
+        blsct::SubAddress recvAddress = blsct_km->GetSubAddress();
         blsct::DoublePublicKey dest2 = recvAddress.GetKeys();
         viewKey2 = blsct_km->viewKey;
         BOOST_CHECK(viewKey.IsValid());

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -40,8 +40,8 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
-#include <utility>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <boost/signals2/signal.hpp>
@@ -126,19 +126,12 @@ class ReserveDestination;
 constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::BECH32};
 
 static constexpr uint64_t KNOWN_WALLET_FLAGS =
-        WALLET_FLAG_AVOID_REUSE
-    |   WALLET_FLAG_BLANK_WALLET
-    |   WALLET_FLAG_KEY_ORIGIN_METADATA
-    |   WALLET_FLAG_LAST_HARDENED_XPUB_CACHED
-    |   WALLET_FLAG_DISABLE_PRIVATE_KEYS
-    |   WALLET_FLAG_DESCRIPTORS
-    |   WALLET_FLAG_BLSCT
-    |   WALLET_FLAG_EXTERNAL_SIGNER;
+    WALLET_FLAG_AVOID_REUSE | WALLET_FLAG_BLANK_WALLET | WALLET_FLAG_KEY_ORIGIN_METADATA | WALLET_FLAG_LAST_HARDENED_XPUB_CACHED | WALLET_FLAG_DISABLE_PRIVATE_KEYS | WALLET_FLAG_DESCRIPTORS | WALLET_FLAG_BLSCT | WALLET_FLAG_EXTERNAL_SIGNER;
 
 static constexpr uint64_t MUTABLE_WALLET_FLAGS =
-        WALLET_FLAG_AVOID_REUSE;
+    WALLET_FLAG_AVOID_REUSE;
 
-static const std::map<std::string,WalletFlags> WALLET_FLAG_MAP{
+static const std::map<std::string, WalletFlags> WALLET_FLAG_MAP{
     {"avoid_reuse", WALLET_FLAG_AVOID_REUSE},
     {"blank", WALLET_FLAG_BLANK_WALLET},
     {"key_origin_metadata", WALLET_FLAG_KEY_ORIGIN_METADATA},
@@ -146,8 +139,7 @@ static const std::map<std::string,WalletFlags> WALLET_FLAG_MAP{
     {"disable_private_keys", WALLET_FLAG_DISABLE_PRIVATE_KEYS},
     {"descriptor_wallet", WALLET_FLAG_DESCRIPTORS},
     {"blsct_wallet", WALLET_FLAG_BLSCT},
-    {"external_signer", WALLET_FLAG_EXTERNAL_SIGNER}
-};
+    {"external_signer", WALLET_FLAG_EXTERNAL_SIGNER}};
 
 /** A wrapper to reserve an address from a wallet
  *
@@ -182,8 +174,7 @@ protected:
 public:
     //! Construct a ReserveDestination object. This does NOT reserve an address yet
     explicit ReserveDestination(CWallet* pwallet, OutputType type)
-      : pwallet(pwallet)
-      , type(type) { }
+        : pwallet(pwallet), type(type) {}
 
     ReserveDestination(const ReserveDestination&) = delete;
     ReserveDestination& operator=(const ReserveDestination&) = delete;
@@ -205,8 +196,7 @@ public:
 /**
  * Address book data.
  */
-struct CAddressBookData
-{
+struct CAddressBookData {
     /**
      * Address label which is always nullopt for change addresses. For sending
      * and receiving addresses, it will be set to an arbitrary label string
@@ -249,7 +239,7 @@ struct CAddressBookData
 
 inline std::string PurposeToString(AddressPurpose p)
 {
-    switch(p) {
+    switch (p) {
     case AddressPurpose::RECEIVE: return "receive";
     case AddressPurpose::SEND: return "send";
     case AddressPurpose::REFUND: return "refund";
@@ -259,20 +249,22 @@ inline std::string PurposeToString(AddressPurpose p)
 
 inline std::optional<AddressPurpose> PurposeFromString(std::string_view s)
 {
-    if (s == "receive") return AddressPurpose::RECEIVE;
-    else if (s == "send") return AddressPurpose::SEND;
-    else if (s == "refund") return AddressPurpose::REFUND;
+    if (s == "receive")
+        return AddressPurpose::RECEIVE;
+    else if (s == "send")
+        return AddressPurpose::SEND;
+    else if (s == "refund")
+        return AddressPurpose::REFUND;
     return {};
 }
 
-struct CRecipient
-{
+struct CRecipient {
     CScript scriptPubKey;
     CAmount nAmount;
     bool fSubtractFeeFromAmount;
 };
 
-class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
+class WalletRescanReserver; // forward declarations for ScanForWalletTransactions/RescanFromTime
 /**
  * A CWallet maintains a set of transactions and balances, and provides the ability to create new transactions.
  */
@@ -300,7 +292,7 @@ private:
      * prompt rebroadcasts (see ResendWalletTransactions()). */
     bool fBroadcastTransactions = false;
     // Local time that the tip block was received. Used to schedule wallet rebroadcasts.
-    std::atomic<int64_t> m_best_block_time {0};
+    std::atomic<int64_t> m_best_block_time{0};
 
     /**
      * Used to keep track of spent outpoints, and
@@ -457,7 +449,11 @@ public:
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 
     /** Interface for accessing chain state. */
-    interfaces::Chain& chain() const { assert(m_chain); return *m_chain; }
+    interfaces::Chain& chain() const
+    {
+        assert(m_chain);
+        return *m_chain;
+    }
 
     const CWalletTx* GetWalletTx(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
@@ -485,7 +481,11 @@ public:
     bool IsTxImmatureCoinBase(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! check whether we support the named feature
-    bool CanSupportFeature(enum WalletFeature wf) const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return IsFeatureSupported(nWalletVersion, wf); }
+    bool CanSupportFeature(enum WalletFeature wf) const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+    {
+        AssertLockHeld(cs_wallet);
+        return IsFeatureSupported(nWalletVersion, wf);
+    }
 
     bool IsSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
@@ -510,7 +510,7 @@ public:
     bool IsScanning() const { return fScanningWallet; }
     bool IsScanningWithPassphrase() const { return m_scanning_with_passphrase; }
     SteadyClock::duration ScanningDuration() const { return fScanningWallet ? SteadyClock::now() - m_scanning_start.load() : SteadyClock::duration{}; }
-    double ScanningProgress() const { return fScanningWallet ? (double) m_scanning_progress : 0; }
+    double ScanningProgress() const { return fScanningWallet ? (double)m_scanning_progress : 0; }
 
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
     void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -518,7 +518,12 @@ public:
     //! Upgrade DescriptorCaches
     void UpgradeDescriptorCache() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; return true; }
+    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+    {
+        AssertLockHeld(cs_wallet);
+        nWalletVersion = nVersion;
+        return true;
+    }
 
     //! Marks destination as previously spent.
     void LoadAddressPreviouslySpent(const CTxDestination& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -537,14 +542,14 @@ public:
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 
-    void GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     unsigned int ComputeTimeSmart(const CWalletTx& wtx, bool rescanning_old_block) const;
 
     /**
      * Increment the next transaction order id
      * @return next transaction order id
      */
-    int64_t IncOrderPosNext(WalletBatch *batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    int64_t IncOrderPosNext(WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     DBErrors ReorderTransactions();
 
     void MarkDirty();
@@ -561,7 +566,7 @@ public:
      * Add the transaction to the wallet, wrapping it up inside a CWalletTx
      * @return the recently added wtx pointer or nullptr if there was a db write error.
      */
-    CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool fFlushOnClose=true, bool rescanning_old_block = false);
+    CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx = nullptr, bool fFlushOnClose = true, bool rescanning_old_block = false);
     bool LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const interfaces::BlockInfo& block) override;
@@ -570,7 +575,9 @@ public:
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
 
     struct ScanResult {
-        enum { SUCCESS, FAILURE, USER_ABORT } status = SUCCESS;
+        enum { SUCCESS,
+               FAILURE,
+               USER_ABORT } status = SUCCESS;
 
         //! Hash and height of most recent block that was successfully scanned.
         //! Unset if no blocks were scanned due to read errors or the chain
@@ -616,12 +623,12 @@ public:
      * return error
      */
     TransactionError FillPSBT(PartiallySignedTransaction& psbtx,
-                  bool& complete,
-                  int sighash_type = SIGHASH_DEFAULT,
-                  bool sign = true,
-                  bool bip32derivs = true,
-                  size_t* n_signed = nullptr,
-                  bool finalize = true) const;
+                              bool& complete,
+                              int sighash_type = SIGHASH_DEFAULT,
+                              bool sign = true,
+                              bool bip32derivs = true,
+                              size_t* n_signed = nullptr,
+                              bool finalize = true) const;
 
     /**
      * Submit the transaction to the node's mempool and then relay to peers.
@@ -638,7 +645,7 @@ public:
     bool SubmitTxMemoryPoolAndRelay(CWalletTx& wtx, std::string& err_string, bool relay) const
         EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool DummySignTx(CMutableTransaction &txNew, const std::vector<CTxOut> &txouts, const CCoinControl* coin_control = nullptr) const;
+    bool DummySignTx(CMutableTransaction& txNew, const std::vector<CTxOut>& txouts, const CCoinControl* coin_control = nullptr) const;
 
     bool ImportScripts(const std::set<CScript> scripts, int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -651,7 +658,7 @@ public:
      * cannot fund the transaction otherwise. */
     bool m_spend_zero_conf_change{DEFAULT_SPEND_ZEROCONF_CHANGE};
     bool m_signal_rbf{DEFAULT_WALLET_RBF};
-    bool m_allow_fallback_fee{true}; //!< will be false if -fallbackfee=0
+    bool m_allow_fallback_fee{true};                //!< will be false if -fallbackfee=0
     CFeeRate m_min_fee{DEFAULT_TRANSACTION_MINFEE}; //!< Override with -mintxfee
     /**
      * If fee estimation does not have enough data to provide estimates, use this fee instead.
@@ -660,8 +667,8 @@ public:
      */
     CFeeRate m_fallback_fee{DEFAULT_FALLBACK_FEE};
 
-     /** If the cost to spend a change output at this feerate is greater than the value of the
-      * output itself, just drop it to fees. */
+    /** If the cost to spend a change output at this feerate is greater than the value of the
+     * output itself, just drop it to fees. */
     CFeeRate m_discard_rate{DEFAULT_DISCARD_FEE};
 
     /** When the actual feerate is less than the consolidate feerate, we will tend to make transactions which
@@ -686,11 +693,14 @@ public:
     /** Number of pre-generated keys/scripts by each spkm (part of the look-ahead process, used to detect payments) */
     int64_t m_keypool_size{DEFAULT_KEYPOOL_SIZE};
 
+    /** Active wallet account **/
+    int64_t m_current_account{0};
+
     /** Notify external script when a wallet transaction comes in or is updated (handled by -walletnotify) */
     std::string m_notify_tx_changed_script;
 
     size_t KeypoolCountExternalKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool TopUpKeyPool(unsigned int kpSize = 0);
+    bool TopUpKeyPool(unsigned int kpSize = 0, bool fBlsct = true);
 
     std::optional<int64_t> GetOldestKeyPoolTime() const;
 
@@ -758,12 +768,17 @@ public:
     bool EraseAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const std::string& id) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     unsigned int GetKeyPoolSize() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    unsigned int GetSubAddressPoolSize(const uint64_t& account) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! signify that a particular wallet feature is now used.
     void SetMinVersion(enum WalletFeature, WalletBatch* batch_in = nullptr) override;
 
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
-    int GetVersion() const { LOCK(cs_wallet); return nWalletVersion; }
+    int GetVersion() const
+    {
+        LOCK(cs_wallet);
+        return nWalletVersion;
+    }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -778,7 +793,7 @@ public:
     void Close();
 
     /** Wallet is about to be unloaded */
-    boost::signals2::signal<void ()> NotifyUnload;
+    boost::signals2::signal<void()> NotifyUnload;
 
     /**
      * Address book entry changed.
@@ -796,19 +811,19 @@ public:
     boost::signals2::signal<void(const uint256& hashTx, ChangeType status)> NotifyTransactionChanged;
 
     /** Show progress e.g. for rescan */
-    boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;
+    boost::signals2::signal<void(const std::string& title, int nProgress)> ShowProgress;
 
     /** Watch-only address added */
-    boost::signals2::signal<void (bool fHaveWatchOnly)> NotifyWatchonlyChanged;
+    boost::signals2::signal<void(bool fHaveWatchOnly)> NotifyWatchonlyChanged;
 
     /** Keypool has new keys */
-    boost::signals2::signal<void ()> NotifyCanGetAddressesChanged;
+    boost::signals2::signal<void()> NotifyCanGetAddressesChanged;
 
     /**
      * Wallet status (encrypted, locked) changed.
      * Note: Called without locks held.
      */
-    boost::signals2::signal<void (CWallet* wallet)> NotifyStatusChanged;
+    boost::signals2::signal<void(CWallet* wallet)> NotifyStatusChanged;
 
     /** Inquire whether this wallet broadcasts transactions. */
     bool GetBroadcastTransactions() const { return fBroadcastTransactions; }
@@ -876,8 +891,9 @@ public:
     };
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template<typename... Params>
-    void WalletLogPrintf(std::string fmt, Params... parameters) const {
+    template <typename... Params>
+    void WalletLogPrintf(std::string fmt, Params... parameters) const
+    {
         LogPrintf(("%s " + fmt).c_str(), GetDisplayName(), parameters...);
     };
 
@@ -1015,6 +1031,7 @@ private:
     CWallet& m_wallet;
     bool m_could_reserve{false};
     NowFn m_now;
+
 public:
     explicit WalletRescanReserver(CWallet& w) : m_wallet(w) {}
 
@@ -1055,7 +1072,7 @@ bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
 //! Remove wallet name from persistent configuration so it will not be loaded on startup.
 bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
 
-bool DummySignInput(const SigningProvider& provider, CTxIn &tx_in, const CTxOut &txout, bool can_grind_r, const CCoinControl* coin_control);
+bool DummySignInput(const SigningProvider& provider, CTxIn& tx_in, const CTxOut& txout, bool can_grind_r, const CCoinControl* coin_control);
 
 bool FillInputToWeight(CTxIn& txin, int64_t target_weight);
 

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -43,6 +43,14 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
         wallet_instance->SetupDescriptorScriptPubKeyMans();
     }
 
+    {
+        auto blsct_man = wallet_instance->GetOrCreateBLSCTKeyMan();
+
+        if (blsct_man) {
+            blsct_man->SetupGeneration();
+        }
+    }
+
     tfm::format(std::cout, "Topping up keypool...\n");
     wallet_instance->TopUpKeyPool();
 }
@@ -74,19 +82,19 @@ static std::shared_ptr<CWallet> MakeWallet(const std::string& name, const fs::pa
             return nullptr;
         } else if (load_wallet_ret == DBErrors::NONCRITICAL_ERROR) {
             tfm::format(std::cerr, "Error reading %s! All keys read correctly, but transaction data"
-                            " or address book entries might be missing or incorrect.",
-                name);
+                                   " or address book entries might be missing or incorrect.",
+                        name);
         } else if (load_wallet_ret == DBErrors::TOO_NEW) {
             tfm::format(std::cerr, "Error loading %s: Wallet requires newer version of %s",
-                name, PACKAGE_NAME);
+                        name, PACKAGE_NAME);
             return nullptr;
         } else if (load_wallet_ret == DBErrors::NEED_REWRITE) {
             tfm::format(std::cerr, "Wallet needed to be rewritten: restart %s to complete", PACKAGE_NAME);
             return nullptr;
         } else if (load_wallet_ret == DBErrors::NEED_RESCAN) {
             tfm::format(std::cerr, "Error reading %s! Some transaction data might be missing or"
-                           " incorrect. Wallet requires a rescan.",
-                name);
+                                   " incorrect. Wallet requires a rescan.",
+                        name);
         } else {
             tfm::format(std::cerr, "Error loading %s", name);
             return nullptr;

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -270,7 +270,7 @@ class ToolWalletTest(BitcoinTestFramework):
         shasum_before = self.wallet_shasum()
         timestamp_before = self.wallet_timestamp()
         self.log.debug('Wallet file timestamp before calling create: {}'.format(timestamp_before))
-        out = "Topping up keypool...\n" + self.get_expected_info_output(name="foo", keypool=2000)
+        out = "Topping up keypool...\n" + self.get_expected_info_output(name="foo", keypool=64)
         self.assert_tool_output(out, '-wallet=foo', 'create')
         shasum_after = self.wallet_shasum()
         timestamp_after = self.wallet_timestamp()
@@ -297,12 +297,12 @@ class ToolWalletTest(BitcoinTestFramework):
 
         assert_equal(0, out['txcount'])
         if not self.options.descriptors:
-            assert_equal(1000, out['keypoolsize'])
-            assert_equal(1000, out['keypoolsize_hd_internal'])
+            assert_equal(32, out['keypoolsize'])
+            assert_equal(32, out['keypoolsize_hd_internal'])
             assert_equal(True, 'hdseedid' in out)
         else:
-            assert_equal(4000, out['keypoolsize'])
-            assert_equal(4000, out['keypoolsize_hd_internal'])
+            assert_equal(128, out['keypoolsize'])
+            assert_equal(128, out['keypoolsize_hd_internal'])
 
         self.log_wallet_timestamp_comparison(timestamp_before, timestamp_after)
         assert_equal(timestamp_before, timestamp_after)

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -76,7 +76,7 @@ class AddressTypeTest(BitcoinTestFramework):
             ["-addresstype=p2sh-segwit"],
             ["-addresstype=p2sh-segwit", "-changetype=bech32"],
             ["-addresstype=bech32"],
-            ["-changetype=p2sh-segwit"],
+            ["-changetype=p2sh-segwit", "-addresstype=bech32"],
             [],
         ]
         # whitelist all peers to speed up tx relay / mempool sync

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -71,7 +71,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         self.num_nodes = 2
         # This test isn't testing txn relay/timing, so set whitelist on the
         # peers for instant txn relay. This speeds up the test run time 2-3x.
-        self.extra_args = [["-whitelist=noban@127.0.0.1"]] * self.num_nodes
+        self.extra_args = [["-whitelist=noban@127.0.0.1", "-addresstype=bech32"]] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -53,10 +53,10 @@ class WalletBackupTest(BitcoinTestFramework):
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
         # whitelist all peers to speed up tx relay / mempool sync
         self.extra_args = [
-            ["-whitelist=noban@127.0.0.1", "-keypool=100"],
-            ["-whitelist=noban@127.0.0.1", "-keypool=100"],
-            ["-whitelist=noban@127.0.0.1", "-keypool=100"],
-            ["-whitelist=noban@127.0.0.1"],
+            ["-whitelist=noban@127.0.0.1", "-keypool=100", "-addresstype=bech32"],
+            ["-whitelist=noban@127.0.0.1", "-keypool=100", "-addresstype=bech32"],
+            ["-whitelist=noban@127.0.0.1", "-keypool=100", "-addresstype=bech32"],
+            ["-whitelist=noban@127.0.0.1", "-addresstype=bech32"],
         ]
         self.rpc_timeout = 120
 

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -29,7 +29,7 @@ class WalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.extra_args = [[
-            "-dustrelayfee=0", "-walletrejectlongchains=0", "-whitelist=noban@127.0.0.1"
+            "-dustrelayfee=0", "-walletrejectlongchains=0", "-whitelist=noban@127.0.0.1", "-addresstype=bech32"
         ]] * self.num_nodes
         self.setup_clean_chain = True
         self.supports_cli = False


### PR DESCRIPTION
This PR adds support for the use of a SubAddress pool and the generation of different receiving addresses.

`getnewaddress` RPC method pulls addresses from the pool and shows to the requester receiving addresses.

By default it generates addresses under account `0`.

It also introduces changes in `blsct::PublicKey` to store the underlying point as a `MclG1Point` object, instead of a byte vector, since deserialisation of the vector is a expensive operation.