### PR TITLE
Use bech32_mod-based double public key support in DestinationEncoder and DecodeDestination

### DIFF
--- a/src/bech32_mod.cpp
+++ b/src/bech32_mod.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "blsct/double_public_key.h"
+#include <blsct/double_public_key.h>
 #include <bech32_mod.h>
 #include <util/vector.h>
 

--- a/src/bech32_mod.cpp
+++ b/src/bech32_mod.cpp
@@ -237,5 +237,49 @@ DecodeResult Decode(const std::string& str) {
     return {result, std::move(hrp), data(values.begin(), values.end() - 8)};
 }
 
+std::string EncodeDoublePublicKey(
+    const CChainParams& params,
+    const Encoding encoding,
+    const blsct::DoublePublicKey& dpk
+) {
+    std::vector<uint8_t> dpk_v8 = dpk.GetVch();
+    std::vector<uint8_t> dpk_v5;
+    dpk_v5.reserve(DOUBLE_PUBKEY_ENC_SIZE);
+
+    // ignoring the return value since this conversion always succeeds
+    ConvertBits<8, 5, true>([&](uint8_t c) { dpk_v5.push_back(c); }, dpk_v8.begin(), dpk_v8.end());
+
+    return Encode(encoding, params.Bech32ModHRP(), dpk_v5);
+}
+
+bool DecodeDoublePublicKey(
+    const CChainParams& params,
+    const std::string& str,
+    std::vector<uint8_t>& data
+) {
+    const auto hrp = ToLower(str.substr(0, params.Bech32ModHRP().size()));
+
+    // str needs to be of the expected length and have the expected hrp
+    if (str.size() != bech32_mod::DOUBLE_PUBKEY_ENC_SIZE
+        || hrp != params.Bech32ModHRP()
+        || str[params.Bech32ModHRP().size()] != '1'
+    ) return false;
+
+    // decode to 5-bit based byte vector
+    const auto dec = bech32_mod::Decode(str);
+
+    // check if it has expected encoding and the data is of the expected length
+    if ((dec.encoding != bech32_mod::Encoding::BECH32 && dec.encoding != bech32_mod::Encoding::BECH32M)
+        || dec.data.size() != 154
+    ) return false;
+
+    // The data part consists of two concatenated 48-byte public keys
+    data.reserve(blsct::DoublePublicKey::SIZE);
+    if (!ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, dec.data.begin(), dec.data.end())) {
+        return false;
+    }
+    return true;
+}
+
 } // namespace bech32_mod
 

--- a/src/bech32_mod.cpp
+++ b/src/bech32_mod.cpp
@@ -211,12 +211,7 @@ DecodeResult Decode(const std::string& str) {
     if (!CheckCharacters(str, errors)) return {};
     size_t pos = str.rfind('1');
 
-    // double public key bech32 string is 165-byte long and consists of:
-    // - 2-byte hrp
-    // - 1-byte separator '1'
-    // - 154-byte key data (96 bytes / 5 bits = 153.6)
-    // - 8-byte checksum
-    if (str.size() != 165  // double public key should be encoded to 165-byte bech32 string
+    if (str.size() != DOUBLE_PUBKEY_ENC_SIZE
         || pos == str.npos  // separator '1' should be included
         || pos == 0  // hrp part should not be empty
         || pos + 9 > str.size()  // data part should not be empty

--- a/src/bech32_mod.h
+++ b/src/bech32_mod.h
@@ -16,6 +16,7 @@
 
 #include <chainparams.h>
 #include <blsct/double_public_key.h>
+#include <optional>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -61,12 +62,10 @@ std::string EncodeDoublePublicKey(
     const blsct::DoublePublicKey& dpk
 );
 
-/** Decode a Bech32 or Bech32m string to concatenation of two serialized public keys
- *  Overwrite given data with the concatenated public keys if succeeded. */
-bool DecodeDoublePublicKey(
+/** Decode a Bech32 or Bech32m string to a DoublePublicKey. */
+std::optional<blsct::DoublePublicKey> DecodeDoublePublicKey(
     const CChainParams& params,
-    const std::string& str,
-    std::vector<uint8_t>& data
+    const std::string& str
 );
 
 } // namespace bech32_mod

--- a/src/bech32_mod.h
+++ b/src/bech32_mod.h
@@ -14,6 +14,8 @@
 #ifndef BITCOIN_BECH32_MOD_H
 #define BITCOIN_BECH32_MOD_H
 
+#include <chainparams.h>
+#include <blsct/double_public_key.h>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -51,6 +53,21 @@ struct DecodeResult
 
 /** Decode a Bech32 or Bech32m string. */
 DecodeResult Decode(const std::string& str);
+
+/** Encode DoublePublicKey to Bech32 or Bech32m string. Encoding must be one of BECH32 or BECH32M. */
+std::string EncodeDoublePublicKey(
+    const CChainParams& params,
+    const Encoding encoding,
+    const blsct::DoublePublicKey& dpk
+);
+
+/** Decode a Bech32 or Bech32m string to concatination of two serialized public keys
+ *  Overwrite given data with the concatenated public keys if succeeded. */
+bool DecodeDoublePublicKey(
+    const CChainParams& params,
+    const std::string& str,
+    std::vector<uint8_t>& data
+);
 
 } // namespace bech32_mod
 

--- a/src/bech32_mod.h
+++ b/src/bech32_mod.h
@@ -21,6 +21,13 @@
 namespace bech32_mod
 {
 
+// double public key after encoding to bech32_mod is 165-byte long consisting of:
+// - 2-byte hrp
+// - 1-byte separator '1'
+// - 154-byte key data (96 bytes / 5 bits = 153.6)
+// - 8-byte checksum
+constexpr size_t DOUBLE_PUBKEY_ENC_SIZE = 2 + 1 + 154 + 8;
+
 enum class Encoding {
     INVALID, //!< Failed decoding
 

--- a/src/bech32_mod.h
+++ b/src/bech32_mod.h
@@ -15,7 +15,6 @@
 #define BITCOIN_BECH32_MOD_H
 
 #include <chainparams.h>
-#include <blsct/double_public_key.h>
 #include <optional>
 #include <stdint.h>
 #include <string>
@@ -23,13 +22,6 @@
 
 namespace bech32_mod
 {
-
-// double public key after encoding to bech32_mod is 165-byte long consisting of:
-// - 2-byte hrp
-// - 1-byte separator '1'
-// - 154-byte key data (96 bytes / 5 bits = 153.6)
-// - 8-byte checksum
-constexpr size_t DOUBLE_PUBKEY_ENC_SIZE = 2 + 1 + 154 + 8;
 
 enum class Encoding {
     INVALID, //!< Failed decoding
@@ -55,18 +47,8 @@ struct DecodeResult
 /** Decode a Bech32 or Bech32m string. */
 DecodeResult Decode(const std::string& str);
 
-/** Encode DoublePublicKey to Bech32 or Bech32m string. Encoding must be one of BECH32 or BECH32M. */
-std::string EncodeDoublePublicKey(
-    const CChainParams& params,
-    const Encoding encoding,
-    const blsct::DoublePublicKey& dpk
-);
-
-/** Decode a Bech32 or Bech32m string to a DoublePublicKey. */
-std::optional<blsct::DoublePublicKey> DecodeDoublePublicKey(
-    const CChainParams& params,
-    const std::string& str
-);
+// 96 bytes / 5 bits = 153.6 -> 154 bytes
+constexpr size_t DOUBLE_PUBKEY_DATA_ENC_SIZE = 154;
 
 } // namespace bech32_mod
 

--- a/src/bech32_mod.h
+++ b/src/bech32_mod.h
@@ -61,7 +61,7 @@ std::string EncodeDoublePublicKey(
     const blsct::DoublePublicKey& dpk
 );
 
-/** Decode a Bech32 or Bech32m string to concatination of two serialized public keys
+/** Decode a Bech32 or Bech32m string to concatenation of two serialized public keys
  *  Overwrite given data with the concatenated public keys if succeeded. */
 bool DecodeDoublePublicKey(
     const CChainParams& params,

--- a/src/blsct/arith/mcl/mcl_g1point.cpp
+++ b/src/blsct/arith/mcl/mcl_g1point.cpp
@@ -185,9 +185,7 @@ std::vector<uint8_t> MclG1Point::GetVch() const
 bool MclG1Point::SetVch(const std::vector<uint8_t>& b)
 {
     if (mclBnG1_deserialize(&m_point, &b[0], b.size()) == 0) {
-        mclBnG1 x;
-        mclBnG1_clear(&x);
-        m_point = x;
+        mclBnG1_clear(&m_point);
         return false;
     }
     return true;

--- a/src/blsct/double_public_key.cpp
+++ b/src/blsct/double_public_key.cpp
@@ -22,6 +22,7 @@ DoublePublicKey::DoublePublicKey(const std::vector<unsigned char>& keys)
 
     vk = vkData;
     sk = skData;
+    is_fully_built = true;
 }
 
 CKeyID DoublePublicKey::GetID() const
@@ -76,7 +77,7 @@ bool DoublePublicKey::operator<(const DoublePublicKey& rhs) const
 
 bool DoublePublicKey::IsValid() const
 {
-    return vk.IsValid() && sk.IsValid();
+    return is_fully_built && vk.IsValid() && sk.IsValid();
 }
 
 std::vector<unsigned char> DoublePublicKey::GetVkVch() const

--- a/src/blsct/double_public_key.cpp
+++ b/src/blsct/double_public_key.cpp
@@ -3,16 +3,23 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blsct/double_public_key.h>
+#include <blsct/arith/mcl/mcl.h>
 
 namespace blsct {
 
 DoublePublicKey::DoublePublicKey(const std::vector<unsigned char>& keys)
 {
     if (keys.size() != SIZE) return;
-    std::vector<unsigned char> vkData(SIZE / 2);
-    std::vector<unsigned char> skData(SIZE / 2);
-    std::copy(keys.begin(), keys.begin() + SIZE / 2, vkData.begin());
-    std::copy(keys.begin() + SIZE / 2, keys.end(), skData.begin());
+
+    std::vector<unsigned char> vkData(blsct::PublicKey::SIZE);
+    std::vector<unsigned char> skData(blsct::PublicKey::SIZE);
+    std::copy(keys.begin(), keys.begin() + blsct::PublicKey::SIZE, vkData.begin());
+    std::copy(keys.begin() + blsct::PublicKey::SIZE, keys.end(), skData.begin());
+
+    // check vkData and skData are valid serialization of points
+    MclG1Point p;
+    if (!p.SetVch(vkData) || !p.SetVch(skData)) return;
+
     vk = vkData;
     sk = skData;
 }

--- a/src/blsct/double_public_key.h
+++ b/src/blsct/double_public_key.h
@@ -21,7 +21,7 @@ private:
     PublicKey sk;
 
 public:
-    static constexpr size_t SIZE = 48 * 2;
+    static constexpr size_t SIZE = blsct::PublicKey::SIZE * 2;
 
     DoublePublicKey() {}
     DoublePublicKey(const PublicKey& vk_, const PublicKey& sk_) : vk(vk_), sk(sk_) {}

--- a/src/blsct/double_public_key.h
+++ b/src/blsct/double_public_key.h
@@ -19,14 +19,21 @@ private:
 
     PublicKey vk;
     PublicKey sk;
+    bool is_fully_built = false;
 
 public:
     static constexpr size_t SIZE = blsct::PublicKey::SIZE * 2;
 
-    DoublePublicKey() {}
-    DoublePublicKey(const PublicKey& vk_, const PublicKey& sk_) : vk(vk_), sk(sk_) {}
-    DoublePublicKey(const Point& vk_, const Point& sk_) : vk(vk_), sk(sk_) {}
-    DoublePublicKey(const std::vector<unsigned char>& vk_, const std::vector<unsigned char>& sk_) : vk(vk_), sk(sk_) {}
+    DoublePublicKey() : is_fully_built(true) {}
+    DoublePublicKey(const PublicKey& vk_, const PublicKey& sk_) : vk(vk_), sk(sk_), is_fully_built(true) {}
+    DoublePublicKey(const Point& vk_, const Point& sk_) : vk(vk_), sk(sk_), is_fully_built(true) {}
+
+    DoublePublicKey(const std::vector<unsigned char>& vk_, const std::vector<unsigned char>& sk_) : vk(vk_), sk(sk_)
+    {
+        MclG1Point p;
+        is_fully_built = p.SetVch(vk_) && p.SetVch(sk_);
+    }
+
     DoublePublicKey(const std::vector<unsigned char>& keys);
 
     SERIALIZE_METHODS(DoublePublicKey, obj) { READWRITE(obj.vk, obj.sk); }

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -141,13 +141,13 @@ public:
         vSeeds.emplace_back("seed.bitcoin.wiz.biz."); // Jason Maurice
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);
-        base58Prefixes[BLSCT_ADDRESS] = {73,33};
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,128);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
         bech32_hrp = "bc";
+        bech32_mod_hrp = "nv";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_main), std::end(chainparams_seed_main));
 
@@ -250,13 +250,13 @@ public:
         vSeeds.emplace_back("testnet-seed.bluematt.me."); // Just a static list of stable node(s), only supports x9
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
-        base58Prefixes[BLSCT_ADDRESS] = {73,33};
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "tb";
+        bech32_mod_hrp = "tn";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_test), std::end(chainparams_seed_test));
 
@@ -376,13 +376,13 @@ public:
         vFixedSeeds.clear();
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
-        base58Prefixes[BLSCT_ADDRESS] = {73,33};
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "tb";
+        bech32_mod_hrp = "tn";
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
@@ -505,13 +505,13 @@ public:
         };
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
-        base58Prefixes[BLSCT_ADDRESS] = {73,33};
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "bcrt";
+        bech32_mod_hrp = "tn";
     }
 };
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -82,7 +82,6 @@ public:
         SECRET_KEY,
         EXT_PUBLIC_KEY,
         EXT_SECRET_KEY,
-        BLSCT_ADDRESS,
 
         MAX_BASE58_TYPES
     };
@@ -124,6 +123,7 @@ public:
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::string& Bech32HRP() const { return bech32_hrp; }
+    const std::string& Bech32ModHRP() const { return bech32_mod_hrp; }
     const std::vector<uint8_t>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
 
@@ -176,6 +176,7 @@ protected:
     std::vector<std::string> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
     std::string bech32_hrp;
+    std::string bech32_mod_hrp;
     ChainType m_chain_type;
     CBlock genesis;
     std::vector<uint8_t> vFixedSeeds;

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -90,19 +90,19 @@ public:
 
 CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
 {
-    std::vector<unsigned char> data;
-    uint160 hash;
-    error_str = "";
-
-    // first try to decode str as a double public key
-    if (bech32_mod::DecodeDoublePublicKey(params, str, data)) {
-        auto dpk = blsct::DoublePublicKey(data);
+    // first try to decode str to a double public key
+    auto maybe_dpk = bech32_mod::DecodeDoublePublicKey(params, str);
+    if (maybe_dpk) {
+        auto dpk = maybe_dpk.value();
         if (dpk.IsValid()) {
             return CTxDestination(dpk);
         }
         // if invalid, try other types of destinations
     }
-    data.clear();
+
+    std::vector<unsigned char> data;
+    uint160 hash;
+    error_str = "";
 
     // Note this will be false if it is a valid Bech32 address for a different network
     bool is_bech32 = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -29,7 +29,7 @@ public:
 
     std::string operator()(const blsct::DoublePublicKey& id) const
     {
-        return bech32_mod::EncodeDoublePublicKey(
+        return EncodeDoublePublicKey(
             m_params,
             bech32_mod::Encoding::BECH32M,
             id
@@ -91,7 +91,7 @@ public:
 CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
 {
     // first try to decode str to a double public key
-    auto maybe_dpk = bech32_mod::DecodeDoublePublicKey(params, str);
+    auto maybe_dpk = DecodeDoublePublicKey(params, str);
     if (maybe_dpk) {
         auto dpk = maybe_dpk.value();
         if (dpk.IsValid()) {
@@ -319,4 +319,54 @@ bool IsValidDestinationString(const std::string& str, const CChainParams& params
 bool IsValidDestinationString(const std::string& str)
 {
     return IsValidDestinationString(str, Params());
+}
+
+std::string EncodeDoublePublicKey(
+    const CChainParams& params,
+    const bech32_mod::Encoding encoding,
+    const blsct::DoublePublicKey& dpk
+) {
+    std::vector<uint8_t> dpk_v8 = dpk.GetVch();
+    std::vector<uint8_t> dpk_v5;
+    dpk_v5.reserve(DOUBLE_PUBKEY_ENC_SIZE);
+
+    // ignoring the return value since this conversion always succeeds
+    ConvertBits<8, 5, true>([&](uint8_t c) { dpk_v5.push_back(c); }, dpk_v8.begin(), dpk_v8.end());
+
+    return Encode(encoding, params.Bech32ModHRP(), dpk_v5);
+}
+
+std::optional<blsct::DoublePublicKey> DecodeDoublePublicKey(
+    const CChainParams& params,
+    const std::string& str
+) {
+    const auto hrp = ToLower(str.substr(0, params.Bech32ModHRP().size()));
+
+    // str needs to be of the expected length and have the expected hrp
+    if (str.size() != DOUBLE_PUBKEY_ENC_SIZE
+        || hrp != params.Bech32ModHRP()
+        || str[params.Bech32ModHRP().size()] != '1'
+    ) return std::nullopt;
+
+    // decode to 5-bit based byte vector
+    const auto dec = bech32_mod::Decode(str);
+
+    // check if it has expected encoding and the data is of the expected length
+    if ((dec.encoding != bech32_mod::Encoding::BECH32 && dec.encoding != bech32_mod::Encoding::BECH32M)
+        || dec.data.size() != 154
+    ) return std::nullopt;
+
+    // The data part consists of two concatenated 48-byte public keys
+    std::vector<uint8_t> data;
+    data.reserve(blsct::DoublePublicKey::SIZE);
+    if (!ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, dec.data.begin(), dec.data.end())) {
+        return std::nullopt;
+    }
+
+    blsct::DoublePublicKey dpk(data);
+    if (dpk.IsValid()) {
+        return dpk;
+    } else {
+        return std::nullopt;
+    }
 }

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_KEY_IO_H
 #define BITCOIN_KEY_IO_H
 
+#include <bech32_mod.h>
 #include <blsct/double_public_key.h>
 #include <chainparams.h>
 #include <key.h>
@@ -27,5 +28,25 @@ CTxDestination DecodeDestination(const std::string& str);
 CTxDestination DecodeDestination(const std::string& str, std::string& error_msg, std::vector<int>* error_locations = nullptr);
 bool IsValidDestinationString(const std::string& str);
 bool IsValidDestinationString(const std::string& str, const CChainParams& params);
+
+// double public key after encoding to bech32_mod is 165-byte long consisting of:
+// - 2-byte hrp
+// - 1-byte separator '1'
+// - 154-byte data
+// - 8-byte checksum
+constexpr size_t DOUBLE_PUBKEY_ENC_SIZE = 2 + 1 + bech32_mod::DOUBLE_PUBKEY_DATA_ENC_SIZE + 8;
+
+/** Encode DoublePublicKey to Bech32 or Bech32m string. Encoding must be one of BECH32 or BECH32M. */
+std::string EncodeDoublePublicKey(
+    const CChainParams& params,
+    const bech32_mod::Encoding encoding,
+    const blsct::DoublePublicKey& dpk
+);
+
+/** Decode a Bech32 or Bech32m string to a DoublePublicKey. */
+std::optional<blsct::DoublePublicKey> DecodeDoublePublicKey(
+    const CChainParams& params,
+    const std::string& str
+);
 
 #endif // BITCOIN_KEY_IO_H

--- a/src/test/bech32_mod_tests.cpp
+++ b/src/test/bech32_mod_tests.cpp
@@ -62,7 +62,7 @@ std::string gen_random_byte_str(const size_t size) {
     std::uniform_int_distribution<uint8_t> dist(0, 255);
 
     for (size_t i = 0; i < size; ++i) {
-        s += dist(gen);
+        s += static_cast<char>(dist(gen));
     }
     return s;
 }

--- a/src/test/bech32_mod_tests.cpp
+++ b/src/test/bech32_mod_tests.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "validationinterface.h"
 #include <bech32_mod.h>
 #include <test/util/str.h>
 #include <util/strencodings.h>
@@ -76,7 +77,6 @@ size_t test_error_detection(
     const size_t num_tests,
     const bool expect_errors
 ) {
-    std::string hrp = "nv";
     size_t unexpected_results = 0;
 
     for (size_t i=0; i<num_tests; ++i) {
@@ -89,7 +89,7 @@ size_t test_error_detection(
             std::vector<uint8_t> dpk_v5;
             ConvertBits<8, 5, true>([&](uint8_t c) { dpk_v5.push_back(c); }, dpk_v8.begin(), dpk_v8.end());
 
-            auto dpk_bech32 = bech32_mod::Encode(encoding, hrp, dpk_v5);
+            auto dpk_bech32 = bech32_mod::Encode(encoding, "nv", dpk_v5);
             embed_errors(dpk_bech32, num_errors);
 
             auto res = bech32_mod::Decode(dpk_bech32);

--- a/src/test/bech32_mod_tests.cpp
+++ b/src/test/bech32_mod_tests.cpp
@@ -3,7 +3,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "validationinterface.h"
 #include <bech32_mod.h>
 #include <test/util/str.h>
 #include <util/strencodings.h>

--- a/src/test/bech32_mod_tests.cpp
+++ b/src/test/bech32_mod_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "blsct/double_public_key.h"
+#include <blsct/double_public_key.h>
 #include <bech32_mod.h>
 #include <test/util/str.h>
 #include <util/strencodings.h>

--- a/src/test/bech32_mod_tests.cpp
+++ b/src/test/bech32_mod_tests.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "blsct/double_public_key.h"
 #include <bech32_mod.h>
 #include <test/util/str.h>
 #include <util/strencodings.h>
@@ -53,20 +54,15 @@ void embed_errors(std::string& s, const size_t num_errors) {
     }
 }
 
-std::string gen_random_str(const size_t size) {
-    static const char charset[] =
-        "0123456789"
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        "abcdefghijklmnopqrstuvwxyz";
-    const size_t max_index = (sizeof(charset) - 1);
+std::string gen_random_byte_str(const size_t size) {
     std::string s;
 
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::uniform_int_distribution<size_t> dist(0, max_index);
+    std::uniform_int_distribution<size_t> dist(0, 255);
 
     for (size_t i = 0; i < size; ++i) {
-        s += charset[dist(gen)];
+        s += dist(gen);
     }
     return s;
 }
@@ -80,8 +76,8 @@ size_t test_error_detection(
 
     for (size_t i=0; i<num_tests; ++i) {
         for (auto encoding : {bech32_mod::Encoding::BECH32, bech32_mod::Encoding::BECH32M}) {
-            // generate random 96-byte double public key
-            std::string dpk = gen_random_str(96);
+            // generate random double public key
+            std::string dpk = gen_random_byte_str(blsct::DoublePublicKey::SIZE);
 
             // convert 8-bit vector to 5-bit vector
             std::vector<uint8_t> dpk_v8(dpk.begin(), dpk.end());
@@ -122,3 +118,4 @@ BOOST_AUTO_TEST_CASE(bech32_mod_test_detecting_errors)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/test/bech32_mod_tests.cpp
+++ b/src/test/bech32_mod_tests.cpp
@@ -59,7 +59,7 @@ std::string gen_random_byte_str(const size_t size) {
 
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::uniform_int_distribution<size_t> dist(0, 255);
+    std::uniform_int_distribution<uint8_t> dist(0, 255);
 
     for (size_t i = 0; i < size; ++i) {
         s += dist(gen);

--- a/src/test/blsct/keys_tests.cpp
+++ b/src/test/blsct/keys_tests.cpp
@@ -200,4 +200,47 @@ BOOST_AUTO_TEST_CASE(aggretate_empty_public_keys)
     BOOST_CHECK_THROW(pks.Aggregate(), std::runtime_error);
 }
 
+BOOST_AUTO_TEST_CASE(double_public_key_with_bad_input_vector)
+{
+    {
+        // empty input vector
+        std::vector<uint8_t> keys;
+        blsct::DoublePublicKey dpk(keys);
+        BOOST_CHECK(dpk.IsValid() == false);
+    }
+    {
+        // input vector of invalid shorter size
+        auto g = MclG1Point::GetBasePoint();
+        auto keys = g.GetVch();
+
+        // drop the last element
+        keys.pop_back();
+
+        blsct::DoublePublicKey dpk(keys);
+        BOOST_CHECK(dpk.IsValid() == false);
+    }
+    {
+        // input vector of invalid larger size
+        auto g = MclG1Point::GetBasePoint();
+        auto keys = g.GetVch();
+
+        // append an element
+        keys.push_back(1);
+
+        blsct::DoublePublicKey dpk(keys);
+        BOOST_CHECK(dpk.IsValid() == false);
+    }
+    {
+        // input vector of valid size with bad content
+        auto g = MclG1Point::GetBasePoint();
+        auto keys = g.GetVch();
+
+        // alter keys[0] from 151 to 152
+        keys[0] = keys[0] + 1;
+
+        blsct::DoublePublicKey dpk(keys);
+        BOOST_CHECK(dpk.IsValid() == false);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "script/standard.h"
+#include <script/standard.h>
 #include <test/data/key_io_invalid.json.h>
 #include <test/data/key_io_valid.json.h>
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "script/standard.h"
 #include <test/data/key_io_invalid.json.h>
 #include <test/data/key_io_valid.json.h>
 
@@ -146,17 +147,30 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
     }
 }
 
-BOOST_AUTO_TEST_CASE(key_io_blsct)
+BOOST_AUTO_TEST_CASE(key_io_double_public_key_endode_decode)
 {
-    // Generate two random public keys
-    blsct::PublicKey keyFromPointRandom{MclG1Point::Rand()};
-    blsct::PublicKey keyFromPointRandom2{MclG1Point::Rand()};
+    // randomly generated double public key
+    blsct::PublicKey pk1(MclG1Point::Rand());
+    blsct::PublicKey pk2(MclG1Point::Rand());
+    blsct::DoublePublicKey dpk(pk1, pk2);
 
-    blsct::DoublePublicKey doubleKey{keyFromPointRandom, keyFromPointRandom2};
+    // check if encoding and then decoding it
+    // produces the original double public key
+    auto act = DecodeDestination(EncodeDestination(dpk.GetVch()));
 
-    auto dest = EncodeDestination(doubleKey);
+    BOOST_CHECK(act == CTxDestination(dpk));
+}
 
-    BOOST_CHECK(DecodeDestination(dest) == CTxDestination(doubleKey));
+BOOST_AUTO_TEST_CASE(key_io_double_public_key_decode_encode)
+{
+    // a valid bech32_mod encoded double public key
+    std::string dpk_bech32_mod = "nv1jlca8fe3jltegf54vwxyl2dvplpk3rz0ja6tjpdpfcar79cm43vxc40g8luh5xh0lva0qzkmytrthftje04fqnt8g6yq3j8t2z552ryhy8dnpyfgqyj58ypdptp43f32u28htwu0r37y9su6332jn0c0fcvan8l53m";
+
+    // check if decoding and then encoding it produces
+    // the original bech32_mod encoded double public key
+    auto act = EncodeDestination(DecodeDestination(dpk_bech32_mod));
+
+    BOOST_CHECK(act == dpk_bech32_mod);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Using the bech32_mod module added in #133, this PR replaces base58-based public key support in DestinationEncoder and DecodeDestination in key_io.cpp with bech32-based one.