### PR TITLE
Use the same G and H generators in range proof and set membership proof. Allow TokenId and blsct::Message as a seed for range proof

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -865,9 +865,9 @@ libbitcoin_common_a_SOURCES = \
   blsct/public_keys.cpp \
   blsct/range_proof/bulletproofs/amount_recovery_request.cpp \
   blsct/range_proof/bulletproofs/amount_recovery_result.cpp \
-  blsct/range_proof/bulletproofs/range_proof.cpp \
   blsct/range_proof/bulletproofs/range_proof_logic.cpp \
   blsct/range_proof/bulletproofs/range_proof_with_transcript.cpp \
+  blsct/range_proof/bulletproofs/range_proof.cpp \
   blsct/range_proof/bulletproofs_plus/amount_recovery_request.cpp \
   blsct/range_proof/bulletproofs_plus/amount_recovery_result.cpp \
   blsct/range_proof/bulletproofs_plus/range_proof.cpp \
@@ -1167,9 +1167,9 @@ libnavcoinkernel_la_SOURCES = \
   blsct/public_keys.cpp \
   blsct/range_proof/bulletproofs/amount_recovery_request.cpp \
   blsct/range_proof/bulletproofs/amount_recovery_result.cpp \
-  blsct/range_proof/bulletproofs/range_proof.cpp \
   blsct/range_proof/bulletproofs/range_proof_logic.cpp \
   blsct/range_proof/bulletproofs/range_proof_with_transcript.cpp \
+  blsct/range_proof/bulletproofs/range_proof.cpp \
   blsct/range_proof/bulletproofs_plus/amount_recovery_request.cpp \
   blsct/range_proof/bulletproofs_plus/amount_recovery_result.cpp \
   blsct/range_proof/bulletproofs_plus/range_proof.cpp \

--- a/src/blsct/building_block/generator_deriver.cpp
+++ b/src/blsct/building_block/generator_deriver.cpp
@@ -1,14 +1,17 @@
 #include <blsct/building_block/generator_deriver.h>
 #include <blsct/arith/mcl/mcl.h>
+#include <blsct/common.h>
+#include <stdexcept>
 #include <util/strencodings.h>
 #include <hash.h>
 #include <optional>
+#include <variant>
 
 template <typename Point>
 Point GeneratorDeriver<Point>::Derive(
     const Point& p,
     const size_t index,
-    const std::optional<TokenId>& token_id
+    const std::optional<Seed>& opt_seed
 ) const {
     std::vector<uint8_t> serialized_p = p.GetVch();
 
@@ -17,13 +20,29 @@ Point GeneratorDeriver<Point>::Derive(
         os << n;
         return os.str();
     };
-    std::string hash_preimage =
-        HexStr(serialized_p) +
-        salt_str +
-        num_to_str(index) +
-        (token_id.has_value() ? token_id.value().ToString() : "") +
-        (token_id.has_value() ? "nft" + num_to_str(token_id.value().subid) : "");
+    std::string hash_preimage;
 
+    if (std::holds_alternative<TokenId>(opt_seed.value())) {
+        auto token_id = std::get<TokenId>(opt_seed.value());
+        hash_preimage =
+            HexStr(serialized_p) +
+            salt_str +
+            num_to_str(index) +
+            token_id.ToString() +
+            "nft" + num_to_str(token_id.subid)
+        ;
+    } else if (std::holds_alternative<blsct::Message>(opt_seed.value())) {
+        auto message = std::get<Bytes>(opt_seed.value());
+        hash_preimage =
+            HexStr(serialized_p) +
+            salt_str +
+            num_to_str(index) +
+            "DERIVATION_FROM_MESSAGE" +
+            HexStr(message)
+        ;
+    } else {
+        throw new std::runtime_error("Unexpected seed type");
+    }
     HashWriter ss{};
     ss << hash_preimage;
     auto hash = ss.GetHash();
@@ -40,5 +59,5 @@ template
 typename Mcl::Point GeneratorDeriver<typename Mcl::Point>::Derive(
     const Mcl::Point& p,
     const size_t index,
-    const std::optional<TokenId>& token_id
+    const std::optional<Seed>& seed
 ) const;

--- a/src/blsct/building_block/generator_deriver.h
+++ b/src/blsct/building_block/generator_deriver.h
@@ -8,16 +8,22 @@
 #include <ctokens/tokenid.h>
 #include <optional>
 #include <string>
+#include <variant>
+#include <vector>
+
+using Bytes = std::vector<uint8_t>;
 
 template <typename Point>
 class GeneratorDeriver {
 public:
+    using Seed = std::variant<TokenId, Bytes>;
+
     GeneratorDeriver(const std::string& salt_str): salt_str{salt_str} {}
 
     Point Derive(
         const Point& p,
         const size_t index,
-        const std::optional<TokenId>& token_id = std::nullopt
+        const std::optional<Seed>& opt_token_id = TokenId()
     ) const;
 
 private:
@@ -25,3 +31,4 @@ private:
 };
 
 #endif // NAVCOIN_BLSCT_GENERATOR_DERIVER_H
+

--- a/src/blsct/building_block/imp_inner_prod_arg.cpp
+++ b/src/blsct/building_block/imp_inner_prod_arg.cpp
@@ -3,7 +3,6 @@
 #include <blsct/building_block/imp_inner_prod_arg.h>
 #include <blsct/building_block/lazy_points.h>
 #include <blsct/common.h>
-#include <blsct/range_proof/bulletproofs/range_proof.h>
 #include <blsct/range_proof/setup.h>
 
 template <typename T>

--- a/src/blsct/building_block/imp_inner_prod_arg.h
+++ b/src/blsct/building_block/imp_inner_prod_arg.h
@@ -7,7 +7,6 @@
 
 #include <blsct/arith/mcl/mcl.h>
 #include <blsct/arith/elements.h>
-#include <blsct/range_proof/bulletproofs/range_proof.h>
 #include <hash.h>
 #include <vector>
 #include <optional>

--- a/src/blsct/range_proof/bulletproofs/amount_recovery_request.cpp
+++ b/src/blsct/range_proof/bulletproofs/amount_recovery_request.cpp
@@ -5,6 +5,10 @@
 #include <blsct/arith/mcl/mcl.h>
 #include <blsct/range_proof/bulletproofs/amount_recovery_request.h>
 #include <blsct/range_proof/bulletproofs/range_proof_with_transcript.h>
+#include <blsct/range_proof/bulletproofs/range_proof.h>
+
+#include <stdexcept>
+#include <variant>
 
 namespace bulletproofs {
 
@@ -15,7 +19,7 @@ AmountRecoveryRequest<T> AmountRecoveryRequest<T>::of(RangeProof<T>& proof, type
 
     AmountRecoveryRequest<T> req{
         1,
-        proof.token_id,
+        proof.seed,
         proof_with_transcript.x,
         proof_with_transcript.z,
         proof.Vs,
@@ -23,7 +27,8 @@ AmountRecoveryRequest<T> AmountRecoveryRequest<T>::of(RangeProof<T>& proof, type
         proof.Rs,
         proof.mu,
         proof.tau_x,
-        nonce};
+        nonce
+    };
     return req;
 }
 template AmountRecoveryRequest<Mcl> AmountRecoveryRequest<Mcl>::of(RangeProof<Mcl>&, Mcl::Point&);

--- a/src/blsct/range_proof/bulletproofs/amount_recovery_request.h
+++ b/src/blsct/range_proof/bulletproofs/amount_recovery_request.h
@@ -6,8 +6,8 @@
 #define NAVCOIN_BLSCT_ARITH_RANGE_PROOF_BULLETPROOFS_AMOUNT_RECOVERY_REQUEST_H
 
 #include <blsct/arith/elements.h>
+#include <blsct/building_block/generator_deriver.h>
 #include <blsct/range_proof/bulletproofs/range_proof.h>
-#include <ctokens/tokenid.h>
 
 namespace bulletproofs {
 
@@ -19,7 +19,7 @@ struct AmountRecoveryRequest
     using Points = Elements<Point>;
 
     size_t id;
-    TokenId token_id;
+    typename GeneratorDeriver<T>::Seed seed;
     Scalar x;
     Scalar z;
     Points Vs;
@@ -29,7 +29,10 @@ struct AmountRecoveryRequest
     Scalar tau_x;
     Point nonce;
 
-    static AmountRecoveryRequest<T> of(RangeProof<T>& proof, Point& nonce);
+    static AmountRecoveryRequest<T> of(
+        RangeProof<T>& proof,
+        Point& nonce
+    );
 };
 
 } // namespace bulletproofs

--- a/src/blsct/range_proof/bulletproofs/range_proof.cpp
+++ b/src/blsct/range_proof/bulletproofs/range_proof.cpp
@@ -3,15 +3,28 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blsct/range_proof/bulletproofs/range_proof.h>
-#include <blsct/arith/mcl/mcl.h>
+#include <blsct/common.h>
+#include <variant>
 
 namespace bulletproofs {
 
 template <typename T>
 bool RangeProof<T>::operator==(const RangeProof<T>& other) const
 {
-    return range_proof::ProofBase<T>::operator==(other) &&
-        token_id == other.token_id &&
+    using P = range_proof::ProofBase<T>;
+    auto this_parent = static_cast<const P&>(*this);
+    auto other_parent = static_cast<const P&>(other);
+
+    bool seed_matches = false;
+    if (std::holds_alternative<TokenId>(seed) && std::holds_alternative<TokenId>(other.seed)) {
+        seed_matches = std::get<TokenId>(seed) == std::get<TokenId>(other.seed);
+    } else if (std::holds_alternative<blsct::Message>(seed) && std::holds_alternative<blsct::Message>(other.seed)) {
+        seed_matches = std::get<blsct::Message>(seed) == std::get<blsct::Message>(other.seed);
+    }
+
+    return
+        this_parent == other_parent &&
+        seed_matches &&
         A == other.A &&
         S == other.S &&
         T1 == other.T1 &&

--- a/src/blsct/range_proof/bulletproofs/range_proof_logic.h
+++ b/src/blsct/range_proof/bulletproofs/range_proof_logic.h
@@ -5,18 +5,21 @@
 #ifndef NAVCOIN_BLSCT_ARITH_RANGE_PROOF_BULLETPROOFS_RANGE_PROOF_LOGIC_H
 #define NAVCOIN_BLSCT_ARITH_RANGE_PROOF_BULLETPROOFS_RANGE_PROOF_LOGIC_H
 
-#include <optional>
-#include <vector>
-
 #include <blsct/arith/elements.h>
+#include <blsct/building_block/generator_deriver.h>
 #include <blsct/range_proof/common.h>
 #include <blsct/range_proof/bulletproofs/amount_recovery_request.h>
 #include <blsct/range_proof/bulletproofs/amount_recovery_result.h>
+#include <blsct/range_proof/bulletproofs/range_proof.h>
 #include <blsct/range_proof/bulletproofs/range_proof_with_transcript.h>
 #include <blsct/range_proof/recovered_data.h>
 #include <consensus/amount.h>
 #include <ctokens/tokenid.h>
 #include <hash.h>
+
+#include <optional>
+#include <variant>
+#include <vector>
 
 namespace bulletproofs {
 
@@ -28,6 +31,7 @@ class RangeProofLogic
 public:
     using Scalar = typename T::Scalar;
     using Point = typename T::Point;
+    using Seed = typename GeneratorDeriver<T>::Seed;
     using Scalars = Elements<Scalar>;
     using Points = Elements<Point>;
 
@@ -35,7 +39,8 @@ public:
         Scalars& vs,
         Point& nonce,
         const std::vector<uint8_t>& message,
-        const TokenId& token_id) const;
+        const Seed& seed
+    ) const;
 
     bool Verify(
         const std::vector<RangeProof<T>>& proofs

--- a/src/blsct/range_proof/bulletproofs/range_proof_with_transcript.cpp
+++ b/src/blsct/range_proof/bulletproofs/range_proof_with_transcript.cpp
@@ -13,6 +13,7 @@
 #include <blsct/common.h>
 #include <hash.h>
 #include <cmath>
+#include <variant>
 
 namespace bulletproofs {
 

--- a/src/blsct/range_proof/common.cpp
+++ b/src/blsct/range_proof/common.cpp
@@ -6,6 +6,7 @@
 #include <blsct/range_proof/bulletproofs_plus/range_proof.h>
 #include <tinyformat.h>
 #include <stdexcept>
+#include <variant>
 
 namespace range_proof {
 
@@ -197,4 +198,6 @@ template void Common<Mcl>::ValidateProofsBySizes(
     const std::vector<bulletproofs_plus::RangeProof<Mcl>>&
 );
 
+
 }
+

--- a/src/blsct/range_proof/common.h
+++ b/src/blsct/range_proof/common.h
@@ -38,12 +38,6 @@ public:
 
     const Scalar& GetUint64Max() const;
 
-    // static Point GenerateBaseG1PointH(
-    //     const Point& p,
-    //     size_t index,
-    //     TokenId token_id
-    // );
-
     range_proof::GeneratorsFactory<T>& Gf() const;
     const Scalar& Zero() const;
     const Scalar& One() const;

--- a/src/blsct/range_proof/generators.cpp
+++ b/src/blsct/range_proof/generators.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blsct/arith/mcl/mcl.h>
+#include <blsct/arith/mcl/mcl_init.h>
 #include <blsct/building_block/generator_deriver.h>
 #include <blsct/range_proof/generators.h>
 #include <blsct/range_proof/setup.h>
@@ -29,45 +30,49 @@ template <typename T>
 range_proof::GeneratorsFactory<T>::GeneratorsFactory()
 {
     using Point = typename T::Point;
-    using Points = Elements<Point>;
 
     std::lock_guard<std::mutex> lock(GeneratorsFactory<T>::m_init_mutex);
     if (GeneratorsFactory<T>::m_is_initialized) return;
 
-    m_H = Point::GetBasePoint();
-    Points Gi, Hi;
-    m_Gi = Gi;
-    m_Hi = Hi;
+    MclInit x;
 
-    const TokenId default_token_id;
-    const Point default_G = m_deriver.Derive(Point::GetBasePoint(), 0, default_token_id);
-    m_G_cache.insert(std::make_pair(default_token_id, default_G));
+    // H needs to be the nase point in order for the verification process to work
+    m_H = Point::GetBasePoint();
+
+    // Gi, Hi are derived from the base point and default TokenId seed
+    Point base_point = Point::GetBasePoint();
+    auto gi_hi_seed = TokenId();
+    Point p = m_deriver.Derive(base_point, 0, gi_hi_seed);
 
     for (size_t i = 0; i < range_proof::Setup::max_input_value_vec_len; ++i) {
         const size_t base_index = i * 2;
-        Point hi = m_deriver.Derive(default_G, base_index + 1, default_token_id);
-        Point gi = m_deriver.Derive(default_G, base_index + 2, default_token_id);
+        Point hi = m_deriver.Derive(p, base_index + 1, gi_hi_seed);
+        Point gi = m_deriver.Derive(p, base_index + 2, gi_hi_seed);
         m_Hi.Add(hi);
         m_Gi.Add(gi);
     }
+
+    // cache the point for later use
+    m_G_cache.emplace(std::make_pair(gi_hi_seed, p));
 
     m_is_initialized = true;
 }
 template range_proof::GeneratorsFactory<Mcl>::GeneratorsFactory();
 
 template <typename T>
-range_proof::Generators<T> range_proof::GeneratorsFactory<T>::GetInstance(const TokenId& token_id)
+range_proof::Generators<T> range_proof::GeneratorsFactory<T>::GetInstance(const Seed& seed) const
 {
     using Point = typename T::Point;
 
-    // if G for the token_id hasn't been created, create and cache it
-    if (GeneratorsFactory<T>::m_G_cache.count(token_id) == 0) {
-        const Point G = m_deriver.Derive(GeneratorsFactory<T>::m_H, 0, token_id);
-        GeneratorsFactory<T>::m_G_cache.emplace(token_id, G);
+    // if G for the given seed hasn't been created, create and cache it
+    if (GeneratorsFactory<T>::m_G_cache.count(seed) == 0) {
+        const Point G = m_deriver.Derive(GeneratorsFactory<T>::m_H, 0, seed);
+        GeneratorsFactory<T>::m_G_cache.emplace(seed, G);
     }
-    Point G = GeneratorsFactory<T>::m_G_cache[token_id];
+    Point G = GeneratorsFactory<T>::m_G_cache[seed];
 
     Generators<T> gens(m_H, G, m_Gi, m_Hi);
     return gens;
 }
-template range_proof::Generators<Mcl> range_proof::GeneratorsFactory<Mcl>::GetInstance(const TokenId&);
+template range_proof::Generators<Mcl> range_proof::GeneratorsFactory<Mcl>::GetInstance(const Seed&) const;
+

--- a/src/blsct/range_proof/generators.h
+++ b/src/blsct/range_proof/generators.h
@@ -58,18 +58,21 @@ class GeneratorsFactory
 {
     using Point = typename T::Point;
     using Points = Elements<Point>;
+    using Seed = typename GeneratorDeriver<T>::Seed;
 
 public:
     GeneratorsFactory();
 
-    Generators<T> GetInstance(const TokenId& token_id);
+    // derives G from the seed. other generators
+    // are shared amongst all instances
+    Generators<T> GetInstance(const Seed& seed) const;
 
 private:
     inline const static GeneratorDeriver m_deriver =
         GeneratorDeriver<typename T::Point>("bulletproofs");
 
     // G generators are cached
-    inline static std::map<const TokenId, const Point> m_G_cache;
+    inline static std::map<const Seed, const Point> m_G_cache;
 
     inline static Point m_H;
     inline static Points m_Gi;

--- a/src/blsct/set_mem_proof/set_mem_proof_prover.h
+++ b/src/blsct/set_mem_proof/set_mem_proof_prover.h
@@ -7,9 +7,11 @@
 
 #include <vector>
 #include <blsct/arith/elements.h>
+#include <blsct/range_proof/generators.h>
 #include <blsct/set_mem_proof/set_mem_proof_setup.h>
 #include <blsct/set_mem_proof/set_mem_proof.h>
 #include <blsct/building_block/imp_inner_prod_arg.h>
+#include <blsct/common.h>
 #include <hash.h>
 
 template <typename T>
@@ -26,13 +28,15 @@ public:
         const Point& sigma,  // Commitment of the set member
         const Scalar& m,  // Message used for the commitment of the set member
         const Scalar& f,  // Mask f used for the commitment of the set member
-        const Scalar& eta  // Entropy
+        const Scalar& eta_fiat_shamir, // entropy for fiat shamir
+        const blsct::Message& eta_phi // entropy for building generators
     );
 
     static bool Verify(
         const SetMemProofSetup<T>& setup,
         const Points& Ys_src,
-        const Scalar& eta,
+        const Scalar& eta_fiat_shamir,
+        const blsct::Message& eta_phi,
         const SetMemProof<T>& proof  // Output of Prove()
     );
 

--- a/src/blsct/set_mem_proof/set_mem_proof_setup.cpp
+++ b/src/blsct/set_mem_proof/set_mem_proof_setup.cpp
@@ -21,6 +21,8 @@ const SetMemProofSetup<T>& SetMemProofSetup<T>::Get()
     PedersenCommitment<T> pedersen_commitment(g, h);
     x = new SetMemProofSetup<T>(g, h, hs, pedersen_commitment);
 
+    m_gf = new range_proof::GeneratorsFactory<T>();
+
     m_is_initialized = true;
     return *x;
 }
@@ -83,6 +85,14 @@ template
 typename Mcl::Scalar SetMemProofSetup<Mcl>::H4(const std::vector<uint8_t>& msg) const;
 
 template <typename T>
+typename T::Point SetMemProofSetup<T>::H5(const std::vector<uint8_t>& msg) const
+{
+    return GenPoint(msg, 5);
+}
+template
+typename Mcl::Point SetMemProofSetup<Mcl>::H5(const std::vector<uint8_t>& msg) const;
+
+template <typename T>
 typename T::Point SetMemProofSetup<T>::GenPoint(const std::vector<uint8_t>& msg, const uint64_t& i)
 {
     HashWriter hasher{};
@@ -96,25 +106,10 @@ template
 typename Mcl::Point SetMemProofSetup<Mcl>::GenPoint(const std::vector<uint8_t>& msg, const uint64_t& i);
 
 template <typename T>
-typename T::Point SetMemProofSetup<T>::H5(const std::vector<uint8_t>& msg) const
+const range_proof::GeneratorsFactory<T>& SetMemProofSetup<T>::Gf() const
 {
-    return GenPoint(msg, 5);
+    return *m_gf;
 }
 template
-typename Mcl::Point SetMemProofSetup<Mcl>::H5(const std::vector<uint8_t>& msg) const;
+const range_proof::GeneratorsFactory<Mcl>& SetMemProofSetup<Mcl>::Gf() const;
 
-template <typename T>
-typename T::Point SetMemProofSetup<T>::H6(const std::vector<uint8_t>& msg) const
-{
-    return GenPoint(msg, 6);
-}
-template
-typename Mcl::Point SetMemProofSetup<Mcl>::H6(const std::vector<uint8_t>& msg) const;
-
-template <typename T>
-typename T::Point SetMemProofSetup<T>::H7(const std::vector<uint8_t>& msg) const
-{
-    return GenPoint(msg, 7);
-}
-template
-typename Mcl::Point SetMemProofSetup<Mcl>::H7(const std::vector<uint8_t>& msg) const;

--- a/src/blsct/set_mem_proof/set_mem_proof_setup.h
+++ b/src/blsct/set_mem_proof/set_mem_proof_setup.h
@@ -9,6 +9,7 @@
 #include <blsct/arith/elements.h>
 #include <blsct/building_block/generator_deriver.h>
 #include <blsct/building_block/pedersen_commitment.h>
+#include <blsct/range_proof/generators.h>
 #include <mutex>
 
 // N is the maximum size of the set of membership public key
@@ -29,6 +30,8 @@ public:
     const Point h;
     const Points hs;
 
+    const range_proof::GeneratorsFactory<T>& Gf() const;
+
     // Hash functions
     Scalar H1(const std::vector<uint8_t>& msg) const;
     Scalar H2(const std::vector<uint8_t>& msg) const;
@@ -36,8 +39,6 @@ public:
     Scalar H4(const std::vector<uint8_t>& msg) const;
 
     Point H5(const std::vector<uint8_t>& msg) const;
-    Point H6(const std::vector<uint8_t>& msg) const;
-    Point H7(const std::vector<uint8_t>& msg) const;
 
     const PedersenCommitment<T> pedersen;
 
@@ -55,6 +56,8 @@ private:
     static Points GenGenerators(const Point& base_point, const size_t& size);
 
     inline static const GeneratorDeriver m_deriver = GeneratorDeriver<Point>("set_membership_proof");
+
+    inline static range_proof::GeneratorsFactory<T>* m_gf;
     inline static std::mutex m_init_mutex;
     inline static bool m_is_initialized = false;
 };

--- a/src/blsct/wallet/keyman.cpp
+++ b/src/blsct/wallet/keyman.cpp
@@ -528,7 +528,7 @@ bulletproofs::AmountRecoveryResult<Mcl> KeyMan::RecoverOutputs(const std::vector
     for (size_t i = 0; i < outs.size(); i++) {
         CTxOut out = outs[i];
         auto nonce = out.blsctData.blindingKey * viewKey.GetScalar();
-        reqs.push_back(bulletproofs::AmountRecoveryRequest<Mcl>::of({out.blsctData.rangeProof}, nonce));
+        reqs.push_back(bulletproofs::AmountRecoveryRequest<Mcl>::of(out.blsctData.rangeProof, nonce));
     }
 
     return rp.RecoverAmounts(reqs);

--- a/src/blsct/wallet/txfactory_global.cpp
+++ b/src/blsct/wallet/txfactory_global.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <blsct/range_proof/bulletproofs/range_proof.h>
 #include <blsct/wallet/txfactory_global.h>
 
 using T = Mcl;

--- a/src/blsct/wallet/verification.cpp
+++ b/src/blsct/wallet/verification.cpp
@@ -4,6 +4,11 @@
 
 #include <blsct/wallet/verification.h>
 #include <util/strencodings.h>
+#include <blsct/arith/mcl/mcl.h>
+#include <blsct/public_keys.h>
+#include <blsct/range_proof/bulletproofs/range_proof.h>
+#include <blsct/range_proof/bulletproofs/range_proof_logic.h>
+#include <blsct/range_proof/generators.h>
 
 namespace blsct {
 bool VerifyTx(const CTransaction& tx, const CCoinsViewCache& view, const CAmount& blockReward)

--- a/src/blsct/wallet/verification.h
+++ b/src/blsct/wallet/verification.h
@@ -5,10 +5,6 @@
 #ifndef BLSCT_VERIFICATION_H
 #define BLSCT_VERIFICATION_H
 
-#include <blsct/arith/mcl/mcl.h>
-#include <blsct/public_keys.h>
-#include <blsct/range_proof/bulletproofs/range_proof_logic.h>
-#include <blsct/range_proof/generators.h>
 #include <coins.h>
 
 namespace blsct {

--- a/src/test/blsct/building_block/generator_deriver_tests.cpp
+++ b/src/test/blsct/building_block/generator_deriver_tests.cpp
@@ -9,6 +9,7 @@
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
 #include <blsct/building_block/generator_deriver.h>
+#include <blsct/common.h>
 
 using Point = Mcl::Point;
 
@@ -17,28 +18,37 @@ BOOST_FIXTURE_TEST_SUITE(generator_deriver_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(test_derive)
 {
     Point g = Point::GetBasePoint();
-
     std::vector<Point> xs;
-
     GeneratorDeriver<Point> gd("pro-micro");
 
     for (size_t i=0; i<10; ++i) {
-        auto p = gd.Derive(g, i, std::nullopt);
+        auto p = gd.Derive(g, i);
         xs.push_back(p);
     }
 
-    // use token id
-    TokenId token_id(uint256(123));
-    for (size_t i=0; i<10; ++i) {
-        auto p = gd.Derive(g, i, token_id);
-        xs.push_back(p);
+    // token id
+    {
+        TokenId token_id(uint256(123));
+        for (size_t i=0; i<10; ++i) {
+            auto p = gd.Derive(g, i, token_id);
+            xs.push_back(p);
+        }
+
+        // use different base point
+        Point gg = g + g;
+        for (size_t i=0; i<10; ++i) {
+            auto p = gd.Derive(gg, i, token_id);
+            xs.push_back(p);
+        }
     }
 
-    // use different base point
-    Point gg = g + g;
-    for (size_t i=0; i<10; ++i) {
-        auto p = gd.Derive(gg, i, token_id);
-        xs.push_back(p);
+    // blsct::Message
+    {
+        blsct::Message m { 1, 2, 3 };
+        for (uint8_t i=0; i<10; ++i) {
+            auto p = gd.Derive(g, i, m);
+            xs.push_back(p);
+        }
     }
 
     // all derived points should be different

--- a/src/test/blsct/range_proof/bulletproofs/bulletproofs_range_proof_tests.cpp
+++ b/src/test/blsct/range_proof/bulletproofs/bulletproofs_range_proof_tests.cpp
@@ -4,9 +4,12 @@
 
 #include <blsct/range_proof/bulletproofs/range_proof.h>
 #include <blsct/arith/mcl/mcl.h>
+#include <blsct/common.h>
 #include <test/util/setup_common.h>
 #include <boost/test/unit_test.hpp>
 #include <streams.h>
+#include <ctokens/tokenid.h>
+#include <uint256.h>
 
 BOOST_FIXTURE_TEST_SUITE(bulletproofs_range_proof_tests, BasicTestingSetup)
 
@@ -15,7 +18,7 @@ using Point = T::Point;
 using Scalar = T::Scalar;
 using Points = Elements<Point>;
 
-BOOST_AUTO_TEST_CASE(test_equal)
+BOOST_AUTO_TEST_CASE(test_different_seed_type)
 {
     Point g = Point::GetBasePoint();
 
@@ -37,8 +40,11 @@ BOOST_AUTO_TEST_CASE(test_equal)
     Scalar a(4);
     Scalar b(5);
     Scalar t_hat(6);
+    TokenId token_id(uint256(1));
+    blsct::Message msg { 2 };
 
     bulletproofs::RangeProof<T> p;
+    p.seed = token_id;
     p.Vs = Vs;
     p.A = A;
     p.S = S;
@@ -53,8 +59,9 @@ BOOST_AUTO_TEST_CASE(test_equal)
     p.t_hat = t_hat;
 
     bulletproofs::RangeProof<T> q;
+    p.seed = msg;
     q.Vs = Vs;
-    q.A = g;
+    q.A = A;
     q.S = S;
     q.T1 = T1;
     q.T2 = T2;
@@ -70,7 +77,7 @@ BOOST_AUTO_TEST_CASE(test_equal)
     BOOST_CHECK(p != q);
 }
 
-BOOST_AUTO_TEST_CASE(test_de_ser)
+BOOST_AUTO_TEST_CASE(test_message_equal)
 {
     Point g = Point::GetBasePoint();
 
@@ -92,8 +99,189 @@ BOOST_AUTO_TEST_CASE(test_de_ser)
     Scalar a(4);
     Scalar b(5);
     Scalar t_hat(6);
+    blsct::Message msg_1 { 1 };
+    blsct::Message msg_2 { 2 };
 
     bulletproofs::RangeProof<T> p;
+    p.seed = msg_1;
+    p.Vs = Vs;
+    p.A = A;
+    p.S = S;
+    p.T1 = T1;
+    p.T2 = T2;
+    p.mu = mu;
+    p.tau_x = tau_x;
+    p.Ls = Ls;
+    p.Rs = Rs;
+    p.a = a;
+    p.b = b;
+    p.t_hat = t_hat;
+
+    bulletproofs::RangeProof<T> q;
+    p.seed = msg_2;
+    q.Vs = Vs;
+    q.A = A;
+    q.S = S;
+    q.T1 = T1;
+    q.T2 = T2;
+    q.mu = mu;
+    q.tau_x = tau_x;
+    q.Ls = Ls;
+    q.Rs = Rs;
+    q.a = a;
+    q.b = b;
+    q.t_hat = t_hat;
+
+    BOOST_CHECK(p == p);
+    BOOST_CHECK(p != q);
+}
+
+BOOST_AUTO_TEST_CASE(test_token_id_equal)
+{
+    // different A,S
+    {
+        Point g = Point::GetBasePoint();
+
+        Points Vs;
+        Vs.Add(g * 100);
+        Vs.Add(g * 101);
+        Point A = g * 2;
+        Point S = g * 3;
+        Point T1 = g * 4;
+        Point T2 = g * 5;
+        Scalar mu(2);
+        Scalar tau_x(3);
+        Points Ls;
+        Ls.Add(g * 200);
+        Ls.Add(g * 201);
+        Points Rs;
+        Rs.Add(g * 300);
+        Rs.Add(g * 301);
+        Scalar a(4);
+        Scalar b(5);
+        Scalar t_hat(6);
+        TokenId token_id(uint256(6));
+
+        bulletproofs::RangeProof<T> p;
+        p.seed = token_id;
+        p.Vs = Vs;
+        p.A = A;
+        p.S = S;
+        p.T1 = T1;
+        p.T2 = T2;
+        p.mu = mu;
+        p.tau_x = tau_x;
+        p.Ls = Ls;
+        p.Rs = Rs;
+        p.a = a;
+        p.b = b;
+        p.t_hat = t_hat;
+
+        bulletproofs::RangeProof<T> q;
+        p.seed = token_id;
+        q.Vs = Vs;
+        q.A = g;
+        q.S = S;
+        q.T1 = T1;
+        q.T2 = T2;
+        q.mu = mu;
+        q.tau_x = tau_x;
+        q.Ls = Ls;
+        q.Rs = Rs;
+        q.a = a;
+        q.b = b;
+        q.t_hat = t_hat;
+
+        BOOST_CHECK(p == p);
+        BOOST_CHECK(p != q);
+    }
+
+    // different token_id
+    {
+        Point g = Point::GetBasePoint();
+
+        Points Vs;
+        Vs.Add(g * 100);
+        Vs.Add(g * 101);
+        Point A = g * 2;
+        Point S = g * 3;
+        Point T1 = g * 4;
+        Point T2 = g * 5;
+        Scalar mu(2);
+        Scalar tau_x(3);
+        Points Ls;
+        Ls.Add(g * 200);
+        Ls.Add(g * 201);
+        Points Rs;
+        Rs.Add(g * 300);
+        Rs.Add(g * 301);
+        Scalar a(4);
+        Scalar b(5);
+        Scalar t_hat(6);
+        TokenId token_id_1(uint256(1));
+        TokenId token_id_2(uint256(2));
+
+        bulletproofs::RangeProof<T> p;
+        p.seed = token_id_1;
+        p.Vs = Vs;
+        p.A = A;
+        p.S = S;
+        p.T1 = T1;
+        p.T2 = T2;
+        p.mu = mu;
+        p.tau_x = tau_x;
+        p.Ls = Ls;
+        p.Rs = Rs;
+        p.a = a;
+        p.b = b;
+        p.t_hat = t_hat;
+
+        bulletproofs::RangeProof<T> q;
+        p.seed = token_id_2;
+        q.Vs = Vs;
+        q.A = A;
+        q.S = S;
+        q.T1 = T1;
+        q.T2 = T2;
+        q.mu = mu;
+        q.tau_x = tau_x;
+        q.Ls = Ls;
+        q.Rs = Rs;
+        q.a = a;
+        q.b = b;
+        q.t_hat = t_hat;
+
+        BOOST_CHECK(p == p);
+        BOOST_CHECK(p != q);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_de_ser_token_id)
+{
+    Point g = Point::GetBasePoint();
+
+    Points Vs;
+    Vs.Add(g * 100);
+    Vs.Add(g * 101);
+    Point A = g * 2;
+    Point S = g * 3;
+    Point T1 = g * 4;
+    Point T2 = g * 5;
+    Scalar mu(2);
+    Scalar tau_x(3);
+    Points Ls;
+    Ls.Add(g * 200);
+    Ls.Add(g * 201);
+    Points Rs;
+    Rs.Add(g * 300);
+    Rs.Add(g * 301);
+    Scalar a(4);
+    Scalar b(5);
+    Scalar t_hat(6);
+    TokenId token_id(uint256(123));
+
+    bulletproofs::RangeProof<T> p;
+    p.seed = token_id;
     p.Vs = Vs;
     p.A = A;
     p.S = S;

--- a/src/test/blsct/range_proof/range_proof_common_tests.cpp
+++ b/src/test/blsct/range_proof/range_proof_common_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <blsct/arith/mcl/mcl.h>
 #include <blsct/range_proof/common.h>
+#include <blsct/range_proof/bulletproofs/range_proof.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -15,6 +16,56 @@ BOOST_AUTO_TEST_CASE(test_get_num_rounds_excl_last)
 {
     auto num_rounds = range_proof::Common<Mcl>::GetNumRoundsExclLast(64);
     BOOST_CHECK(num_rounds == 12);
+}
+
+BOOST_AUTO_TEST_CASE(test_range_proof_validate_proofs_by_sizes)
+{
+    using T = Mcl;
+
+    auto gen_valid_proof_wo_value_commitments = [](size_t num_inputs) {
+        bulletproofs::RangeProof<T> p;
+        auto n = blsct::Common::GetFirstPowerOf2GreaterOrEqTo(num_inputs);
+        for (size_t i=0; i<n; ++i) {
+            p.Vs.Add(MclG1Point::GetBasePoint());
+        }
+        auto num_rounds = range_proof::Common<T>::GetNumRoundsExclLast(n);
+        for (size_t i=0; i<num_rounds; ++i) {
+            p.Ls.Add(MclG1Point::GetBasePoint());
+            p.Rs.Add(MclG1Point::GetBasePoint());
+        }
+        return p;
+    };
+
+    bulletproofs::RangeProof<T> rp;
+    {
+        // no proof should validate fine
+        std::vector<bulletproofs::RangeProof<T>> proofs;
+        BOOST_CHECK_NO_THROW(range_proof::Common<T>::ValidateProofsBySizes(proofs));
+    }
+    {
+        // no value commitment
+        bulletproofs::RangeProof<T> p;
+        std::vector<bulletproofs::RangeProof<T>> proofs { p };
+        BOOST_CHECK_THROW(range_proof::Common<T>::ValidateProofsBySizes(proofs), std::runtime_error);
+    }
+    {
+        // minimum number of value commitments
+        auto p = gen_valid_proof_wo_value_commitments(1);
+        std::vector<bulletproofs::RangeProof<T>> proofs { p };
+        BOOST_CHECK_NO_THROW(range_proof::Common<T>::ValidateProofsBySizes(proofs));
+    }
+    {
+        // maximum number of value commitments
+        auto p = gen_valid_proof_wo_value_commitments(range_proof::Setup::max_input_values);
+        std::vector<bulletproofs::RangeProof<T>> proofs { p };
+        BOOST_CHECK_NO_THROW(range_proof::Common<T>::ValidateProofsBySizes(proofs));
+    }
+    {
+        // number of value commitments exceeding maximum
+        auto p = gen_valid_proof_wo_value_commitments(range_proof::Setup::max_input_values + 1);
+        std::vector<bulletproofs::RangeProof<T>> proofs { p };
+        BOOST_CHECK_THROW(range_proof::Common<T>::ValidateProofsBySizes(proofs), std::runtime_error);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blsct/set_mem_proof/set_mem_proof_prover_tests.cpp
+++ b/src/test/blsct/set_mem_proof/set_mem_proof_prover_tests.cpp
@@ -94,9 +94,14 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_good_inputs_of_power_of_2)
     Ys.Add(sigma);
     Ys.Add(y4);
 
-    Scalar eta = Scalar::Rand();
-    auto proof = Prover::Prove(setup, Ys, sigma, m, f, eta);
-    auto res = Prover::Verify(setup, Ys, eta, proof);
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
+    auto proof = Prover::Prove(
+        setup, Ys, sigma, m, f, eta_fiat_shamir, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, Ys, eta_fiat_shamir, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, true);
 }
@@ -117,9 +122,14 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_good_inputs_of_non_power_of_2)
     Ys.Add(y2);
     Ys.Add(sigma);
 
-    Scalar eta = Scalar::Rand();
-    auto proof = Prover::Prove(setup, Ys, sigma, m, f, eta);
-    auto res = Prover::Verify(setup, Ys, eta, proof);
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
+    auto proof = Prover::Prove(
+        setup, Ys, sigma, m, f, eta_fiat_shamir, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, Ys, eta_fiat_shamir, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, true);
 }
@@ -149,9 +159,14 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_not_included)
     verify_Ys.Add(y3);
     verify_Ys.Add(y4);
 
-    Scalar eta = Scalar::Rand();
-    auto proof = Prover::Prove(setup, prove_Ys, sigma, m, f, eta);
-    auto res = Prover::Verify(setup, verify_Ys, eta, proof);
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
+    auto proof = Prover::Prove(
+        setup, prove_Ys, sigma, m, f, eta_fiat_shamir, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, verify_Ys, eta_fiat_shamir, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, false);
 }
@@ -181,15 +196,20 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_generated_from_other_inp
     ys.Add(C);
     ys.Add(E);
 
-    Scalar eta = Scalar::Rand();
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
 
     // A proof over the membership of D=A+B=g*(f_a+f_b)+h*(m_a+m_b) should be deemed as invalid
     auto m_d = m_a + m_b;
     auto f_d = f_a + f_b;
     auto D = setup.pedersen.Commit(m_d, f_d);
 
-    auto proof = Prover::Prove(setup, ys, D, m_d, f_d, eta);
-    auto res = Prover::Verify(setup, ys, eta, proof);
+    auto proof = Prover::Prove(
+        setup, ys, D, m_d, f_d, eta_fiat_shamir, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, ys, eta_fiat_shamir, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, false);
 }
@@ -218,9 +238,15 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_in_different_pos)
     verify_Ys.Add(y3);
     verify_Ys.Add(sigma);
 
-    Scalar eta = Scalar::Rand();
-    auto proof = Prover::Prove(setup, prove_Ys, sigma, m, f, eta);
-    auto res = Prover::Verify(setup, verify_Ys, eta, proof);
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
+
+    auto proof = Prover::Prove(
+        setup, prove_Ys, sigma, m, f, eta_fiat_shamir, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, verify_Ys, eta_fiat_shamir, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, false);
 }
@@ -243,10 +269,16 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_different_eta)
     ys.Add(sigma);
     ys.Add(y4);
 
-    Scalar eta_123(123);
-    Scalar eta_456(456);
-    auto proof = Prover::Prove(setup, ys, sigma, m, f, eta_123);
-    auto res = Prover::Verify(setup, ys, eta_456, proof);
+    Scalar eta_fiat_shamir_123(123);
+    Scalar eta_fiat_shamir_456(456);
+    blsct::Message eta_phi { 1, 2, 3 };
+
+    auto proof = Prover::Prove(
+        setup, ys, sigma, m, f, eta_fiat_shamir_123, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, ys, eta_fiat_shamir_456, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, false);
 }
@@ -279,9 +311,15 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_same_sigma_different_ys)
     verify_Ys.Add(sigma);
     verify_Ys.Add(y4_2);
 
-    Scalar eta = Scalar::Rand();
-    auto proof = Prover::Prove(setup, prove_Ys, sigma, m, f, eta);
-    auto res = Prover::Verify(setup, verify_Ys, eta, proof);
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
+
+    auto proof = Prover::Prove(
+        setup, prove_Ys, sigma, m, f, eta_fiat_shamir, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, verify_Ys, eta_fiat_shamir, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, false);
 }
@@ -308,9 +346,15 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_large_size_input)
         }
     }
 
-    Scalar eta = Scalar::Rand();
-    auto proof = Prover::Prove(setup, Ys, sigma, m, f, eta);
-    auto res = Prover::Verify(setup, Ys, eta, proof);
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
+
+    auto proof = Prover::Prove(
+        setup, Ys, sigma, m, f, eta_fiat_shamir, eta_phi
+    );
+    auto res = Prover::Verify(
+        setup, Ys, eta_fiat_shamir, eta_phi, proof
+    );
 
     BOOST_CHECK_EQUAL(res, true);
 }

--- a/src/test/blsct/set_mem_proof/set_mem_proof_setup_tests.cpp
+++ b/src/test/blsct/set_mem_proof/set_mem_proof_setup_tests.cpp
@@ -58,20 +58,6 @@ BOOST_AUTO_TEST_CASE(test_h1_to_h7)
             }
         }
     }
-
-    // the same message should be hashed to different points
-    {
-        Point p5 = setup.H5(msg);
-        Point p6 = setup.H6(msg);
-        Point p7 = setup.H7(msg);
-
-        std::vector<Point> vec {p5, p6, p7};
-        for (size_t i=0; i<vec.size()-1; ++i) {
-            for (size_t j=i+1; j<vec.size(); ++j) {
-                BOOST_CHECK(vec[i] != vec[j]);
-            }
-        }
-    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The changes:
- Introduce Seed of type std::variant<TokenId, blsct::Message>
- Use Seed as an input instead of TokenId for range proof prove and verify functions
- RangeProof class has Seed instead of TokenId
- RangeProof allows de/serialization only when Seed is TokenId 
- Use the G and H generators derived from given Seed in range proof and set membership proof
- Use different source of entropy for phi and fiat shamir in set membership proof
- Update bls to the latest version