### PR TITLE
 Make set membership proof work with range proof in Proof of Stake

### DIFF
--- a/src/blsct/range_proof/generators.cpp
+++ b/src/blsct/range_proof/generators.cpp
@@ -65,13 +65,13 @@ range_proof::Generators<T> range_proof::GeneratorsFactory<T>::GetInstance(const 
     using Point = typename T::Point;
 
     // if G for the given seed hasn't been created, create and cache it
-    if (GeneratorsFactory<T>::m_G_cache.count(seed) == 0) {
-        const Point G = m_deriver.Derive(GeneratorsFactory<T>::m_H, 0, seed);
-        GeneratorsFactory<T>::m_G_cache.emplace(seed, G);
+    if (m_G_cache.count(seed) == 0) {
+        const Point G = m_deriver.Derive(m_H, 0, seed);
+        m_G_cache.emplace(seed, G);
     }
-    Point G = GeneratorsFactory<T>::m_G_cache[seed];
+    Point G = m_G_cache[seed];
 
-    Generators<T> gens(m_H, G, m_Gi, m_Hi);
+    Generators<T> gens(G, m_H, m_Gi, m_Hi);
     return gens;
 }
 template range_proof::Generators<Mcl> range_proof::GeneratorsFactory<Mcl>::GetInstance(const Seed&) const;

--- a/src/blsct/range_proof/generators.h
+++ b/src/blsct/range_proof/generators.h
@@ -21,17 +21,17 @@ struct Generators {
 
 public:
     Generators(
-        const Point& H,
         const Point& G,
+        const Point& H,
         const Points& Gi,
         const Points& Hi
-    ) : H{H}, G{G}, Gi{Gi}, Hi{Hi} {}
+    ) : G{G}, H{H}, Gi{Gi}, Hi{Hi} {}
 
     Points GetGiSubset(const size_t& size) const;
     Points GetHiSubset(const size_t& size) const;
 
-    const Point H;
     const Point G;
+    const Point H;
     const Points Gi;
     const Points Hi;
 };
@@ -69,7 +69,7 @@ public:
 
 private:
     inline const static GeneratorDeriver m_deriver =
-        GeneratorDeriver<typename T::Point>("bulletproofs");
+        GeneratorDeriver<typename T::Point>("proof-of-stake");
 
     // G generators are cached
     inline static std::map<const Seed, const Point> m_G_cache;

--- a/src/blsct/set_mem_proof/set_mem_proof_prover.cpp
+++ b/src/blsct/set_mem_proof/set_mem_proof_prover.cpp
@@ -143,9 +143,13 @@ SetMemProof<T> SetMemProofProver<T>::Prove(
 
     // Commit 1
     Point h2 = setup.H5(Ys.GetVch());
+
     auto gens = setup.Gf().GetInstance(eta_phi);
-    Point h3 = gens.G;
-    Point g2 = gens.H;
+    // generators are swapped to make set mem proof
+    // work with proof of stake. originally in PoS paper
+    // h3 = G and g2 = H
+    Point g2 = gens.G;
+    Point h3 = gens.H;
 
     // generate random scalars
     Scalar alpha = Scalar::Rand(true);
@@ -277,8 +281,11 @@ bool SetMemProofProver<T>::Verify(
     Point h2 = setup.H5(Ys.GetVch());
 
     auto gens = setup.Gf().GetInstance(eta_phi);
-    Point h3 = gens.G;
-    Point g2 = gens.H;
+    // generators are swapped to make set mem proof
+    // work with proof of stake. originally in PoS paper
+    // h3 = G and g2 = H
+    Point g2 = gens.G;
+    Point h3 = gens.H;
 
 retry:
     GEN_FIAT_SHAMIR_VAR(y, fiat_shamir, retry);

--- a/src/blsct/set_mem_proof/set_mem_proof_setup.h
+++ b/src/blsct/set_mem_proof/set_mem_proof_setup.h
@@ -55,7 +55,7 @@ private:
     static Point GenPoint(const std::vector<uint8_t>& msg, const uint64_t& i);
     static Points GenGenerators(const Point& base_point, const size_t& size);
 
-    inline static const GeneratorDeriver m_deriver = GeneratorDeriver<Point>("set_membership_proof");
+    inline static const GeneratorDeriver m_deriver = GeneratorDeriver<Point>("proof-of-stake");
 
     inline static range_proof::GeneratorsFactory<T>* m_gf;
     inline static std::mutex m_init_mutex;

--- a/src/test/blsct/set_mem_proof/set_mem_proof_prover_tests.cpp
+++ b/src/test/blsct/set_mem_proof/set_mem_proof_prover_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "blsct/range_proof/bulletproofs/range_proof.h"
 #define BOOST_UNIT_TEST
 
 #include <boost/test/unit_test.hpp>
@@ -12,6 +11,7 @@
 #include <blsct/arith/mcl/mcl.h>
 #include <blsct/arith/elements.h>
 #include <blsct/building_block/pedersen_commitment.h>
+#include <blsct/range_proof/bulletproofs/range_proof.h>
 #include <blsct/range_proof/bulletproofs/range_proof_logic.h>
 #include <blsct/set_mem_proof/set_mem_proof_prover.h>
 #include <blsct/set_mem_proof/set_mem_proof_setup.h>

--- a/src/test/blsct/set_mem_proof/set_mem_proof_prover_tests.cpp
+++ b/src/test/blsct/set_mem_proof/set_mem_proof_prover_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "blsct/range_proof/bulletproofs/range_proof.h"
 #define BOOST_UNIT_TEST
 
 #include <boost/test/unit_test.hpp>
@@ -11,9 +12,14 @@
 #include <blsct/arith/mcl/mcl.h>
 #include <blsct/arith/elements.h>
 #include <blsct/building_block/pedersen_commitment.h>
+#include <blsct/range_proof/bulletproofs/range_proof_logic.h>
 #include <blsct/set_mem_proof/set_mem_proof_prover.h>
 #include <blsct/set_mem_proof/set_mem_proof_setup.h>
 #include <blsct/set_mem_proof/set_mem_proof.h>
+
+using Scalar = Mcl::Scalar;
+using Scalars = Elements<Scalar>;
+using MsgPair = std::pair<std::string, std::vector<unsigned char>>;
 
 BOOST_FIXTURE_TEST_SUITE(set_mem_proof_prover_tests, BasicTestingSetup)
 
@@ -83,10 +89,12 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_good_inputs_of_power_of_2)
     auto y4 = Point::MapToPoint("y4", Endianness::Little);
 
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
 
     Scalar m = Scalar::Rand();
     Scalar f = Scalar::Rand();
-    auto sigma = setup.pedersen.Commit(m, f);
+    auto sigma = gen.G * m + gen.H * f;
 
     Points Ys;
     Ys.Add(y1);
@@ -112,10 +120,12 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_good_inputs_of_non_power_of_2)
     auto y2 = Point::MapToPoint("y2", Endianness::Little);
 
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
 
     Scalar m = Scalar::Rand();
     Scalar f = Scalar::Rand();
-    auto sigma = setup.pedersen.Commit(m, f);
+    auto sigma = gen.G * m + gen.H * f;
 
     Points Ys;
     Ys.Add(y1);
@@ -141,10 +151,12 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_not_included)
     auto y4 = Point::MapToPoint("y4", Endianness::Little);
 
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
 
     Scalar m = Scalar::Rand();
     Scalar f = Scalar::Rand();
-    auto sigma = setup.pedersen.Commit(m, f);
+    auto sigma = gen.G * m + gen.H * f;
 
     Points prove_Ys;
     prove_Ys.Add(y1);
@@ -174,6 +186,8 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_not_included)
 BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_generated_from_other_inputs)
 {
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
 
     // Commitment set includes A=g*f_a+h*m_a, B=g*f_b+h*m_b, and C=g*f_c+h*m_c
     Scalar m_a = Scalar::Rand();
@@ -202,7 +216,7 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_generated_from_other_inp
     // A proof over the membership of D=A+B=g*(f_a+f_b)+h*(m_a+m_b) should be deemed as invalid
     auto m_d = m_a + m_b;
     auto f_d = f_a + f_b;
-    auto D = setup.pedersen.Commit(m_d, f_d);
+    auto D = gen.G * m_d + gen.H * f_d;
 
     auto proof = Prover::Prove(
         setup, ys, D, m_d, f_d, eta_fiat_shamir, eta_phi
@@ -221,10 +235,12 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_sigma_in_different_pos)
     auto y3 = Point::MapToPoint("y4", Endianness::Little);
 
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
 
     Scalar m = Scalar::Rand();
     Scalar f = Scalar::Rand();
-    auto sigma = setup.pedersen.Commit(m, f);
+    auto sigma = gen.G * m + gen.H * f;
 
     Points prove_Ys;
     prove_Ys.Add(y1);
@@ -258,10 +274,12 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_different_eta)
     auto y4 = Point::MapToPoint("y4", Endianness::Little);
 
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
 
     Scalar m = Scalar::Rand();
     Scalar f = Scalar::Rand();
-    auto sigma = setup.pedersen.Commit(m, f);
+    auto sigma = gen.G * m + gen.H * f;
 
     Points ys;
     ys.Add(y1);
@@ -294,10 +312,12 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_same_sigma_different_ys)
     auto y4_2 = Point::MapToPoint("y4_2", Endianness::Little);
 
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
 
     Scalar m = Scalar::Rand();
     Scalar f = Scalar::Rand();
-    auto sigma = setup.pedersen.Commit(m, f);
+    auto sigma = gen.G * m + gen.H * f;
 
     Points prove_Ys;
     prove_Ys.Add(y1_1);
@@ -328,12 +348,14 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_small_size_same_sigma_different_ys)
 BOOST_AUTO_TEST_CASE(test_prove_verify_large_size_input)
 {
     auto setup = SetMemProofSetup<Arith>::Get();
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
+    Scalar m = Scalar::Rand();
+    Scalar f = Scalar::Rand();
+    auto sigma = gen.G * m + gen.H * f;
 
     const size_t NUM_INPUTS = setup.N;
     Points Ys;
-    Scalar m = Scalar::Rand();
-    Scalar f = Scalar::Rand();
-    Point sigma = setup.pedersen.Commit(m, f);
 
     for (size_t i=0; i<NUM_INPUTS; ++i) {
         if (i == NUM_INPUTS / 2) {
@@ -354,6 +376,73 @@ BOOST_AUTO_TEST_CASE(test_prove_verify_large_size_input)
     );
     auto res = Prover::Verify(
         setup, Ys, eta_fiat_shamir, eta_phi, proof
+    );
+
+    BOOST_CHECK_EQUAL(res, true);
+}
+
+static MsgPair GenMsgPair(std::string s)
+{
+    std::vector<unsigned char> message { s.begin(), s.end() };
+    return std::pair(s, message);
+}
+
+static bulletproofs::RangeProof<Arith> CreateTokenIdRangeProof(
+    Point nonce,
+    Scalar value
+) {
+    auto msg = GenMsgPair("test");
+
+    Scalars vs;
+    vs.Add(value);
+
+    bulletproofs::RangeProofLogic<Arith> rp;
+    auto proof = rp.Prove(vs, nonce, msg.second, TokenId());
+
+    return proof;
+}
+
+BOOST_AUTO_TEST_CASE(test_pos_scenario)
+{
+    auto setup = SetMemProofSetup<Arith>::Get();
+
+    auto value = Scalar(12345);
+    auto nonce = Point::Rand();
+    auto gamma = nonce.GetHashWithSalt(100);
+
+    auto range_proof = CreateTokenIdRangeProof(nonce, value);
+    auto stake_c = range_proof.Vs[0];
+
+    std::vector<Point> staked_commitments {
+        Point::MapToPoint("stake_a", Endianness::Little),
+        Point::MapToPoint("stake_b", Endianness::Little),
+        stake_c,
+        Point::MapToPoint("stake_d", Endianness::Little),
+    };
+
+    range_proof::Generators<Arith> gen =
+        setup.Gf().GetInstance(TokenId());
+    auto sigma = gen.G * value + gen.H * gamma;
+
+    Scalar eta_fiat_shamir = Scalar::Rand();
+    blsct::Message eta_phi { 1, 2, 3 };
+
+    auto proof = Prover::Prove(
+        setup,
+        staked_commitments,
+        sigma,
+        value,
+        gamma,
+        eta_fiat_shamir,
+        eta_phi
+    );
+
+    auto res = Prover::Verify(
+        setup,
+        staked_commitments,
+        eta_fiat_shamir,
+        eta_phi,
+        proof
     );
 
     BOOST_CHECK_EQUAL(res, true);


### PR DESCRIPTION
Changes:
- Use the same salt string for `GeneratorDeriver` in range proof and set membership proof
- Swap `G` and `H` generators in set membership prove/verify functions